### PR TITLE
chore(ci): group Dependabot updates and auto-merge green PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,23 +9,47 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Bundle all GitHub Actions bumps into a single PR instead of one per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    # Bundle all Python dependency bumps into a single PR. Keeps changes to
+    # pyproject.toml / uv.lock in one place so they don't have to be merged
+    # separately and don't conflict with each other.
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      uv-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      docker-compose:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,38 @@
+name: Dependabot auto-merge
+
+# Automatically approve and enable auto-merge for Dependabot pull requests.
+# GitHub will only complete the merge once all required status checks (the
+# "Tests" and "Code checks" workflows) pass — see the repository's branch
+# ruleset for the required checks. If checks fail, the PR stays open.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only act on PRs opened by Dependabot.
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve the pull request
+        # The approval (by github-actions[bot]) satisfies the "1 review"
+        # rule so auto-merge can proceed once checks are green.
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
- **Group Dependabot updates per ecosystem** (`.github/dependabot.yml`): each ecosystem (github-actions, pip, uv, docker, docker-compose) now bundles its bumps into a single PR via `groups`. Related changes — e.g. all `pyproject.toml` / `uv.lock` bumps — land together instead of one PR per dependency, so they don't have to be merged separately and won't conflict with each other.
- **Auto-merge workflow** (`.github/workflows/dependabot-auto-merge.yml`): approves and enables auto-merge on Dependabot PRs. GitHub completes the merge **only once the required `Tests` and `Code checks` pass** (green). Failing checks leave the PR open.

## Notes
- The workflow uses `pull_request_target` (no checkout of PR code) so the `GITHUB_TOKEN` can approve/enable auto-merge.
- Auto-merges all severity levels; if you'd rather hold major bumps for manual review, add a `steps.metadata.outputs.update-type` guard.