### PR TITLE
Add filter(), select_related(), load_related() and actualized docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,18 @@ install-python-deps:
 	uv sync --all-extras
 
 # Run Docker Compose to start the database services
-.PHONY: docker-up
-docker-up:
+.PHONY: docker-start
+docker-start:
 	docker compose -f docker-compose.yml up
 
+# Stop the database services
+.PHONY: docker-stop
+docker-stop:
+	docker compose -f docker-compose.yml stop
+
 # Stop and remove all Docker containers defined in the compose file
-.PHONY: docker-down
-docker-down:
+.PHONY: docker-destroy
+docker-destroy:
 	docker compose -f docker-compose.yml down
 
 # Run tests using pytest

--- a/README.md
+++ b/README.md
@@ -51,14 +51,15 @@ DatabaseRegistry.set_default("db1")
 
 # Define models
 class User(Model):
-    id: int | None = Field(default=None, pk=True)
+    id: int | None = Field(default=None)  # `id` is the primary key by default
     username: str
 
 class Product(Model):
-    id: int | None = Field(default=None, pk=True)
+    id: int | None = Field(default=None)
     name: str
     price: float
     in_stock: bool = Field(False)
+    user_id: int | None = Field(default=None)  # foreign key to User
 
     class Meta:
         db_alias = "db2"  # Use the MySQL connection
@@ -68,14 +69,17 @@ async def main():
     # Create tables
     await User.create_table()
     await Product.create_table()
-    # Make queries
+    # Insert rows (the generated primary key is set back on the instance)
     user = User(username="alice")
     await user.save()
-    await Product(name="Laptop", price=2_499.99).save()
-    await Product(name="Phone", price=799.99, in_stock=True).save()
-    # Filtering
+    await Product(name="Laptop", price=2_499.99, user_id=user.id).save()
+    await Product(name="Phone", price=799.99, in_stock=True, user_id=user.id).save()
+    # Query
     users = await User.all()
-    products = await Product.filter(in_stock=True)
+    cheap = await Product.filter(in_stock=True, price__lt=1000)
+    # Eager-load relations without writing SQL (JOIN or batched, your choice)
+    products = await Product.select_related("user").all()        # one JOIN query
+    owners = await User.load_related("products").all()           # batched, avoids N+1
 ```
 
 See the [Usage Guide](docs/USAGE.md) for more details and advanced examples.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -27,7 +27,7 @@ This will:
 If you do not already have a database running locally, you can start the required database services using Docker:
 
 ```sh
-make docker-up
+make docker-start
 ```
 
 This will run `docker compose` to start the database containers defined in `docker-compose.yml`.
@@ -62,4 +62,9 @@ Pre-commit hooks help maintain code quality by running checks before commits. To
 
 ```bash
 pre-commit install
+```
+
+To disable `pre-commit` run:
+```bash
+pre-commit uninstall
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -35,14 +35,14 @@ By default, all models use the default connection. To assign a specific connecti
 from riverorm import Field, Model
 
 class User(Model):
-    id: int
+    id: int | None = Field(default=None)
     username: str
 
     class Meta:
         db_alias = "db1"  # Use the Postgres connection
 
 class Product(Model):
-    id: int
+    id: int | None = Field(default=None)
     name: str
     price: float
     in_stock: bool = Field(True)
@@ -61,66 +61,134 @@ If no connections are registered, or a model's `db_alias` is not found, any DB o
 
 ## Defining Models
 
-Models in RiverORM inherit from `Model` and use type annotations with `Field` for schema definition. Fields support Pydantic validation and metadata.
-
-Example:
+Models in RiverORM inherit from `Model` and use type annotations with `Field` for schema definition. Fields are real Pydantic fields, so you get validation and metadata for free.
 
 ```python
 from riverorm import Field, Model
 
 class Product(Model):
-    id: int = Field(pk=True)
+    id: int | None = Field(default=None)  # `id` is the primary key by default
     name: str
     price: float
     in_stock: bool = Field(True)
 ```
 
+The primary key is the `id` field by default. To use a different primary key,
+set it on the model's `Meta`:
+
+```python
+class Product(Model):
+    sku: str
+    name: str
+
+    class Meta:
+        primary_key = "sku"
+```
+
+> **Note:** the primary key is configured via `Meta.primary_key` (default `"id"`),
+> not via a `Field(pk=True)` argument.
+
 ---
 
 ## Relationships
 
-You can define relationships using type annotations. For example, a `User` with a list of `Order` objects:
+Relationships are declared with a **foreign-key column** plus an annotated
+**relation field** that RiverORM populates for you. A forward relation needs a
+`<name>_id` column and a field typed as the related model; a reverse relation is
+a field typed as a `list[...]` of the related model.
 
 ```python
 class User(Model):
-    id: int
+    id: int | None = Field(default=None)
     username: str
+    # Reverse relation — populated by load_related("orders")
     orders: list["Order"] = Field(default_factory=list)
 
 class Order(Model):
-    id: int
-    user: User
-    product: Product
+    id: int | None = Field(default=None)
+    quantity: int
+    user_id: int | None = Field(default=None)     # foreign key column
+    product_id: int | None = Field(default=None)  # foreign key column
+    # Forward relations — populated by select_related(...) / load_related(...)
+    user: "User | None" = Field(default=None)
+    product: "Product | None" = Field(default=None)
+```
+
+Relation fields (`user`, `product`, `orders`) are *virtual*: they are never
+stored as columns. Only scalar columns — including the `_id` foreign keys —
+are created in the database.
+
+### Eager loading (no manual SQL)
+
+Choose how related data is fetched:
+
+```python
+# select_related: a single SQL JOIN, best for forward (to-one) relations
+orders = await Order.select_related("user", "product").all()
+print(orders[0].user.username)
+
+# load_related: one batched query per relation (avoids N+1); works for
+# forward, reverse, and nested ("__") relations
+users = await User.load_related("orders").all()
+paid = await Order.load_related("product__user").filter(status="paid")
 ```
 
 ---
 
 ## Creating and Using Model Instances
 
-Model instances are created like Pydantic models:
+Model instances are created like Pydantic models. Leave the primary key unset
+to let the database auto-generate it on `save()`:
 
 ```python
-user = User(id=1, username="alice")
-product = Product(id=1, name="Laptop", price=999.99)
-order = Order(id=1, user=user, product=product)
+user = User(username="alice")
+await user.save()  # user.id is populated after insert
+
+product = Product(name="Laptop", price=999.99)
+await product.save()
+
+order = Order(quantity=1, user_id=user.id, product_id=product.id)
+await order.save()
 ```
 
 ---
 
 ## Async Usage
 
-All database operations are async:
+All database operations are async.
 
 ```python
-# Load a product
+# Fetch a single row
 product = await Product.get(id=1)
-# Or products with a filter
+
+# Fetch many rows, optionally with field lookups
 products = await Product.filter(in_stock=True, price__gte=500, price__lt=1000)
-# Update a product
+everything = await Product.all()
+
+# Update: change attributes and save (an existing primary key triggers UPDATE)
 product.name = "Apple MacBook"
-# And save changes
 await product.save()
+
+# Delete
+await product.delete()
 ```
+
+### Filter lookups
+
+`filter()` accepts Django-style field lookups via a `field__operator` suffix:
+
+| Lookup        | SQL        | Example                         |
+| ------------- | ---------- | ------------------------------- |
+| `field`       | `=`        | `filter(in_stock=True)`         |
+| `field__eq`   | `=`        | `filter(status__eq="paid")`     |
+| `field__ne`   | `!=`       | `filter(status__ne="draft")`    |
+| `field__gt`   | `>`        | `filter(price__gt=100)`         |
+| `field__gte`  | `>=`       | `filter(price__gte=100)`        |
+| `field__lt`   | `<`        | `filter(price__lt=1000)`        |
+| `field__lte`  | `<=`       | `filter(price__lte=1000)`       |
+| `field__in`   | `IN (...)` | `filter(id__in=[1, 2, 3])`      |
+
+Multiple lookups are combined with `AND`.
 
 ---
 

--- a/riverorm/models.py
+++ b/riverorm/models.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 from typing import TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -133,6 +134,7 @@ class Model(BaseModel):
 
     @classmethod
     async def all(cls: type[T], limit: int = 1000) -> list[T]:
+        """Fetch all rows for this model (up to the given limit)."""
         query = f'SELECT * FROM "{cls.table_name()}" LIMIT {limit};'
         rows = await cls.db().fetch(query)
         return [cls(**dict(row)) for row in rows]
@@ -148,12 +150,156 @@ class Model(BaseModel):
 
     @classmethod
     async def filter(cls: type[T], **kwargs) -> list[T]:
-        keys = list(kwargs.keys())
-        values = list(kwargs.values())
-        conditions = " AND ".join(f"{k} = ${i + 1}" for i, k in enumerate(keys))
-        query = f'SELECT * FROM "{cls.table_name()}" WHERE {conditions}'
+        """
+        Filter rows using field lookups, e.g. age__gt=18, name="foo".
+        Supported operators: __gt, __lt, __gte, __lte, __ne, __eq (default), __in
+        """
+        ops = {
+            "gt": ">",
+            "lt": "<",
+            "gte": ">=",
+            "lte": "<=",
+            "ne": "!=",
+            "eq": "=",
+            "in": "IN",
+        }
+        conditions = []
+        values: list = []
+        param_idx = 1
+        for key, value in kwargs.items():
+            if "__" in key:
+                field, op = key.rsplit("__", 1)
+                sql_op = ops.get(op)
+                if not sql_op:
+                    raise ValueError(f"Unsupported filter operator: {op}")
+                if op == "in":
+                    assert isinstance(value, (list, tuple)), (
+                        "__in operator requires a list or tuple"
+                    )
+                    placeholders = ", ".join(f"${param_idx + i}" for i in range(len(value)))
+                    conditions.append(f"{field} IN ({placeholders})")
+                    values.extend(value)
+                    param_idx += len(value)
+                else:
+                    conditions.append(f"{field} {sql_op} ${param_idx}")
+                    values.append(value)
+                    param_idx += 1
+            else:
+                conditions.append(f"{key} = ${param_idx}")
+                values.append(value)
+                param_idx += 1
+        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+        query = f'SELECT * FROM "{cls.table_name()}"{where}'
         rows = await cls.db().fetch(query, *values)
         return [cls(**dict(r)) for r in rows]
+
+    @classmethod
+    def select_related(cls: type[T], *related_fields) -> type[T]:
+        """
+        Returns a subclass of the model that fetches related objects using SQL JOIN for FK fields.
+        Only supports direct foreign key relationships (e.g., user_id -> User).
+        """
+        base_table = cls.table_name()
+        model_fields = cls.model_real_fields()
+        # Build mapping: related_field -> (fk_field, related_model)
+        rel_map = {}
+        import sys
+
+        mod = sys.modules[cls.__module__]
+        for rel in related_fields:
+            fk_field = f"{rel}_id"
+            if fk_field not in model_fields:
+                raise ValueError(f"No foreign key field '{fk_field}' for related field '{rel}'")
+            related_model = getattr(mod, rel.capitalize(), None)
+            if related_model is None:
+                raise ValueError(f"Related model class for '{rel}' not found in module {mod}")
+            rel_map[rel] = (fk_field, related_model)
+
+        async def all(cls, limit: int = 1000):
+            base_alias = base_table
+            select_cols = [f'"{base_alias}"."{f}"' for f in model_fields.keys()]
+            join_clauses = []
+            for rel, (fk_field, related_model) in rel_map.items():
+                rel_table = related_model.table_name()
+                rel_alias = rel_table
+                rel_cols = [
+                    f'"{rel_alias}"."{col}" AS {rel}__{col}'
+                    for col in related_model.model_real_fields().keys()
+                ]
+                select_cols.extend(rel_cols)
+                join_clauses.append(
+                    f'LEFT JOIN "{rel_table}" AS "{rel_alias}" '
+                    f'ON "{base_alias}"."{fk_field}" = "{rel_alias}"."id"'
+                )
+            select_sql = ", ".join(select_cols)
+            joins = " ".join(join_clauses)
+            query = (
+                f'SELECT {select_sql} FROM "{base_table}" AS "{base_alias}" {joins} LIMIT {limit};'
+            )
+            rows = await cls.db().fetch(query)
+            return [cls._hydrate_with_related(row) for row in rows]
+
+        async def filter(cls, **kwargs):
+            base_alias = base_table
+            select_cols = [f'"{base_alias}"."{f}"' for f in model_fields.keys()]
+            join_clauses = []
+            for rel, (fk_field, related_model) in rel_map.items():
+                rel_table = related_model.table_name()
+                rel_alias = rel_table
+                rel_cols = [
+                    f'"{rel_alias}"."{col}" AS {rel}__{col}'
+                    for col in related_model.model_real_fields().keys()
+                ]
+                select_cols.extend(rel_cols)
+                join_clauses.append(
+                    f'LEFT JOIN "{rel_table}" AS "{rel_alias}" '
+                    f'ON "{base_alias}"."{fk_field}" = "{rel_alias}"."id"'
+                )
+            select_sql = ", ".join(select_cols)
+            joins = " ".join(join_clauses)
+            conditions = []
+            values = []
+            param_idx = 1
+            for key, value in kwargs.items():
+                conditions.append(f'"{base_alias}"."{key}" = ${param_idx}')
+                values.append(value)
+                param_idx += 1
+            where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+            query = f'SELECT {select_sql} FROM "{base_table}" AS "{base_alias}" {joins}{where};'
+            rows = await cls.db().fetch(query, *values)
+            return [cls._hydrate_with_related(row) for row in rows]
+
+        def _hydrate_with_related(cls, row):
+            base_data = {}
+            related_objs = {}
+            for k, v in dict(row).items():
+                if "__" in k:
+                    rel, col = k.split("__", 1)
+                    related_objs.setdefault(rel, {})[col] = v
+                else:
+                    base_data[k] = v
+            obj = cls(**base_data)
+            for rel, (fk_field, related_model) in rel_map.items():
+                rel_data = related_objs.get(rel)
+                if rel_data and rel_data.get("id") is not None:
+                    obj.__dict__[rel] = related_model(**rel_data)
+                else:
+                    obj.__dict__[rel] = None
+            return obj
+
+        RelatedSelected = type(
+            f"{cls.__name__}RelatedSelected",
+            (cls,),
+            {
+                "_select_related": related_fields,
+                "_rel_map": rel_map,
+                "all": classmethod(all),
+                "filter": classmethod(filter),
+                "_hydrate_with_related": classmethod(_hydrate_with_related),
+                "table_name": classmethod(lambda c: cls.table_name()),
+            },
+        )
+        return RelatedSelected
 
     @classmethod
     async def create_table(cls: type[T]):
@@ -178,3 +324,10 @@ class Model(BaseModel):
     async def drop_table(cls: type[T]):
         sql = f'DROP TABLE IF EXISTS "{cls.table_name()}";'
         return await cls.db().execute(sql)
+
+
+class TimestampedModel(Model):
+    """Model with date-time field: created_at and updated_at."""
+
+    created_at: datetime | None = Field(default=None, description="Creation timestamp")
+    updated_at: datetime | None = Field(default=None, description="Last update timestamp")

--- a/riverorm/models.py
+++ b/riverorm/models.py
@@ -1,6 +1,7 @@
 import re
+from collections.abc import Sequence
 from datetime import datetime
-from typing import TypeVar
+from typing import Any, TypeVar, get_args, get_origin
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.fields import FieldInfo
@@ -10,6 +11,39 @@ from riverorm.db import BaseDatabase, DatabaseRegistry
 from riverorm.utils import is_int_type
 
 T = TypeVar("T", bound="Model")
+
+
+def _camel_to_snake(name: str) -> str:
+    """Convert a CamelCase class name to snake_case (e.g. OrderItem -> order_item)."""
+    name = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    name = re.sub(r"([a-z])([A-Z0-9])", r"\1_\2", name)
+    name = re.sub(r"(\d)([A-Z][a-z])", r"\1_\2", name)
+    return name.lower()
+
+
+def _related_model_from_annotation(annotation: Any) -> tuple[type["Model"] | None, bool]:
+    """
+    Inspect a field annotation and return ``(related_model, is_collection)``.
+
+    Handles ``Model``, ``Model | None``, ``Optional[Model]`` and ``list[Model]`` /
+    ``set[Model]`` / ``tuple[Model, ...]``. Returns ``(None, False)`` for scalar fields.
+    """
+    origin = get_origin(annotation)
+    if origin in (list, set, tuple):
+        args = get_args(annotation)
+        inner = _single_model(args[0]) if args else None
+        return (inner, True)
+    return (_single_model(annotation), False)
+
+
+def _single_model(annotation: Any) -> type["Model"] | None:
+    """Return the ``Model`` subclass referenced by an annotation, unwrapping ``| None``."""
+    if isinstance(annotation, type) and issubclass(annotation, Model):
+        return annotation
+    for arg in get_args(annotation):
+        if isinstance(arg, type) and issubclass(arg, Model):
+            return arg
+    return None
 
 
 class Model(BaseModel):
@@ -63,27 +97,25 @@ class Model(BaseModel):
 
     @classmethod
     def table_name(cls) -> str:
-        def camel_to_snake(name: str) -> str:
-            name = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
-            name = re.sub(r"([a-z])([A-Z0-9])", r"\1_\2", name)
-            name = re.sub(r"(\d)([A-Z][a-z])", r"\1_\2", name)
-            return name.lower()
-
         name: str | None = getattr(cls.Meta, "table_name", None)
         if not name:
-            return camel_to_snake(cls.__name__)
+            return _camel_to_snake(cls.__name__)
         return name
 
     @classmethod
     def model_virtual_fields(cls) -> dict[str, FieldInfo]:
         """
-        Returns a dictionary of model fields with their names as keys and Field objects as values.
+        Returns the relation fields (foreign keys and reverse/collection relations).
+
+        A field is "virtual" when its annotation references another ``Model`` directly
+        (``user: User`` / ``user: User | None``) or as a collection (``orders: list[Order]``).
+        These are populated by ``select_related`` / ``load_related`` and are never stored
+        as columns.
         """
         return {
             name: field
             for name, field in cls.model_fields.items()
-            if getattr(field.annotation, "__origin__", None) in (list, tuple)
-            or (isinstance(field.annotation, type) and issubclass(field.annotation, Model))
+            if _related_model_from_annotation(field.annotation)[0] is not None
         }
 
     @classmethod
@@ -300,6 +332,99 @@ class Model(BaseModel):
             },
         )
         return RelatedSelected
+
+    @classmethod
+    def load_related(cls: type[T], *related_fields: str) -> type[T]:
+        """
+        Eagerly load related objects, avoiding N+1 queries.
+
+        Unlike :meth:`select_related` (which uses a SQL JOIN), this issues one extra
+        batched query per relation and stitches the results in Python. It works for both
+        forward foreign keys (``order.user`` via ``user_id``) and reverse relations
+        (``user.orders``), and supports nesting with ``__`` (e.g. ``"product__user"``).
+
+        Example::
+
+            users = await User.load_related("orders", "products").all()
+            orders = await Order.load_related("user", "product__user").filter(status="paid")
+        """
+        specs = list(related_fields)
+        parent_all = cls.all
+        parent_filter = cls.filter
+
+        async def all(_inner: type[T], limit: int = 1000) -> list[T]:
+            objs = await parent_all(limit=limit)
+            await cls._prefetch_related(objs, specs)
+            return objs
+
+        async def filter(_inner: type[T], **kwargs: Any) -> list[T]:
+            objs = await parent_filter(**kwargs)
+            await cls._prefetch_related(objs, specs)
+            return objs
+
+        return type(
+            f"{cls.__name__}WithRelated",
+            (cls,),
+            {"all": classmethod(all), "filter": classmethod(filter)},
+        )
+
+    @classmethod
+    async def _prefetch_related(cls, objects: Sequence["Model"], specs: list[str]) -> None:
+        """Populate the relations named in ``specs`` on ``objects`` with batched queries."""
+        if not objects or not specs:
+            return
+
+        # Group ``"product__user"`` style specs by their root relation.
+        groups: dict[str, list[str]] = {}
+        for spec in specs:
+            root, _, rest = spec.partition("__")
+            groups.setdefault(root, [])
+            if rest:
+                groups[root].append(rest)
+
+        for root, nested in groups.items():
+            related_model, is_collection = _related_model_from_annotation(
+                cls.model_fields[root].annotation if root in cls.model_fields else None
+            )
+            if related_model is None:
+                raise ValueError(f"'{root}' is not a relation on {cls.__name__}")
+
+            if is_collection:
+                children = await cls._prefetch_reverse(objects, root, related_model)
+            else:
+                children = await cls._prefetch_forward(objects, root, related_model)
+
+            if nested:
+                await related_model._prefetch_related(children, nested)
+
+    @classmethod
+    async def _prefetch_forward(
+        cls, objects: Sequence["Model"], root: str, related_model: type["Model"]
+    ) -> list["Model"]:
+        """Load a forward FK relation (``cls`` has ``<root>_id``) and attach single objects."""
+        fk = f"{root}_id"
+        ids = {getattr(obj, fk) for obj in objects if getattr(obj, fk, None) is not None}
+        related = await related_model.filter(id__in=list(ids)) if ids else []
+        by_pk = {getattr(r, r.Meta.primary_key): r for r in related}
+        for obj in objects:
+            obj.__dict__[root] = by_pk.get(getattr(obj, fk, None))
+        return [obj.__dict__[root] for obj in objects if obj.__dict__.get(root) is not None]
+
+    @classmethod
+    async def _prefetch_reverse(
+        cls, objects: Sequence["Model"], root: str, related_model: type["Model"]
+    ) -> list["Model"]:
+        """Load a reverse relation (related rows point back via ``<cls>_id``) as lists."""
+        back_fk = f"{_camel_to_snake(cls.__name__)}_id"
+        pk = cls.Meta.primary_key
+        ids = [getattr(obj, pk) for obj in objects if getattr(obj, pk, None) is not None]
+        related = await related_model.filter(**{f"{back_fk}__in": ids}) if ids else []
+        grouped: dict[Any, list[Model]] = {}
+        for row in related:
+            grouped.setdefault(getattr(row, back_fk), []).append(row)
+        for obj in objects:
+            obj.__dict__[root] = grouped.get(getattr(obj, pk, None), [])
+        return related
 
     @classmethod
     async def create_table(cls: type[T]):

--- a/tests/models.py
+++ b/tests/models.py
@@ -10,6 +10,8 @@ class User(Model):
     username: str = Field(description="Username of the user")
     email: str | None = Field(default=None, description="Email address of the user")
     is_active: bool = Field(True, description="Is the user active?")
+    # Reverse relations (populated by load_related), never stored as columns.
+    products: list["Product"] = Field(default_factory=list, description="Products owned by user")
     orders: list["Order"] = Field(default_factory=list, description="Orders placed by the user")
 
 
@@ -24,6 +26,8 @@ class Product(Model):
     description: str = Field(description="Description of the product")
     in_stock: bool = Field(True, description="Is the product in stock?")
     user_id: int | None = Field(default=None, description="Owner user id of the product")
+    # Forward and reverse relations (populated by select_related / load_related).
+    user: "User | None" = Field(default=None, description="Owner of the product")
     orders: list["Order"] = Field(default_factory=list, description="Orders for this product")
 
 
@@ -33,8 +37,11 @@ class Order(Model):
     """
 
     id: int | None = Field(default=None, description="Order ID")
-    user: User = Field(description="User who placed the order")
-    product: Product = Field(description="Product ordered")
     quantity: int = Field(description="Quantity of the product ordered")
     total_price: float = Field(description="Total price of the order")
     status: str = Field("pending", description="Order status")
+    user_id: int | None = Field(default=None, description="User who placed the order")
+    product_id: int | None = Field(default=None, description="Product ordered")
+    # Forward relations (populated by select_related / load_related).
+    user: "User | None" = Field(default=None, description="User who placed the order")
+    product: "Product | None" = Field(default=None, description="Product ordered")

--- a/tests/models.py
+++ b/tests/models.py
@@ -23,6 +23,7 @@ class Product(Model):
     price: float = Field(description="Price of the product")
     description: str = Field(description="Description of the product")
     in_stock: bool = Field(True, description="Is the product in stock?")
+    user_id: int | None = Field(default=None, description="Owner user id of the product")
     orders: list["Order"] = Field(default_factory=list, description="Orders for this product")
 
 

--- a/tests/test_load_related.py
+++ b/tests/test_load_related.py
@@ -1,0 +1,57 @@
+import pytest
+
+from tests.models import Order, Product, User
+
+
+@pytest.mark.asyncio
+async def test_load_related_fk_and_reverse(db_setup_and_teardown):
+    # Create user, products, and orders
+    user = await User(username="alice", email="alice@ex.com", is_active=True).save()
+    prod1 = await Product(
+        name="Widget", price=10.0, description="A widget", in_stock=True, user_id=user.id
+    ).save()
+    prod2 = await Product(
+        name="Gadget", price=20.0, description="A gadget", in_stock=False, user_id=user.id
+    ).save()
+    order1 = await Order(user_id=user.id, product_id=prod1.id, quantity=2, total_price=20.0).save()
+    order2 = await Order(user_id=user.id, product_id=prod2.id, quantity=1, total_price=20.0).save()
+
+    # Load user with related products (FK) and orders (reverse FK)
+    UserWithRelated = User.load_related("products", "orders")
+    users = await UserWithRelated.filter(id=user.id)
+    assert len(users) == 1
+    u = users[0]
+    # Should have .products and .orders attributes
+    assert hasattr(u, "products")
+    assert hasattr(u, "orders")
+    # .products is a list of Product
+    assert isinstance(u.products, list)
+    assert all(isinstance(p, Product) for p in u.products)
+    # .orders is a list of Order
+    assert isinstance(u.orders, list)
+    assert all(isinstance(o, Order) for o in u.orders)
+    # Check correct objects are loaded
+    assert {p.id for p in u.products} == {prod1.id, prod2.id}
+    assert {o.id for o in u.orders} == {order1.id, order2.id}
+
+
+@pytest.mark.asyncio
+async def test_load_related_nested(db_setup_and_teardown):
+    # Create user, product, order
+    user = await User(username="bob", email="bob@ex.com", is_active=True).save()
+    prod = await Product(
+        name="Thing", price=5.0, description="A thing", in_stock=True, user_id=user.id
+    ).save()
+    order = await Order(user_id=user.id, product_id=prod.id, quantity=3, total_price=15.0).save()
+
+    # Load order with user and product, and product's user
+    OrderWithRelated = Order.load_related("user", "product", "product__user")
+    orders = await OrderWithRelated.filter(id=order.id)
+    assert len(orders) == 1
+    o = orders[0]
+    assert hasattr(o, "user")
+    assert hasattr(o, "product")
+    assert hasattr(o.product, "user")
+    assert o.user.id == user.id
+    assert o.product.id == prod.id
+    assert o.product.user.id == user.id

--- a/tests/test_orm_features.py
+++ b/tests/test_orm_features.py
@@ -1,0 +1,47 @@
+import pytest
+
+from tests.models import Product, User
+
+
+@pytest.mark.asyncio
+async def test_filter_comparison_operators(db_setup_and_teardown):
+    await User(username="alice", email="alice@ex.com", is_active=True).save()
+    await User(username="bob", email="bob@ex.com", is_active=False).save()
+    await User(username="carol", email="carol@ex.com", is_active=True).save()
+
+    users = await User.filter(id__gt=0)
+    assert len(users) == 3
+
+    users = await User.filter(id__lt=1000)
+    assert len(users) == 3
+
+    users = await User.filter(id__gt=1, id__lt=3)
+    assert len(users) == 1
+    assert users[0].username == "bob"
+
+    users = await User.filter(username__ne="bob")
+    assert len(users) == 2
+    assert all(u.username != "bob" for u in users)
+
+    users = await User.filter(username__in=["alice", "carol"])
+    assert len(users) == 2
+    assert {u.username for u in users} == {"alice", "carol"}
+
+    users = await User.filter(is_active=True)
+    assert len(users) == 2
+    assert all(u.is_active for u in users)
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_returns_all_objects(db_setup_and_teardown):
+    await User(username="eve", email="eve@ex.com", is_active=True).save()
+    await User(username="frank", email="frank@ex.com", is_active=False).save()
+    await Product(name="Thing", price=5.0, description="A thing", in_stock=True, user_id=1).save()
+
+    users = await User.all()
+    products = await Product.all()
+
+    assert len(users) == 2
+    assert {u.username for u in users} == {"eve", "frank"}
+    assert len(products) == 1
+    assert products[0].name == "Thing"

--- a/tests/test_select_related.py
+++ b/tests/test_select_related.py
@@ -1,0 +1,41 @@
+import pytest
+
+from tests.models import Product, User
+
+
+@pytest.mark.asyncio
+async def test_select_related_fetches_user_with_product(db_setup_and_teardown):
+    user = await User(username="alice", email="alice@ex.com", is_active=True).save()
+    product = await Product(
+        name="Widget", price=10.0, description="A widget", in_stock=True, user_id=user.id
+    ).save()
+
+    # Fetch product with related user using select_related
+    ProductWithUser = Product.select_related("user")
+    products = await ProductWithUser.filter(id=product.id)
+    assert len(products) == 1
+    prod = products[0]
+    # The related user should be fetched and attached
+    assert hasattr(prod, "user")
+    assert isinstance(prod.user, User)
+    assert prod.user.id == user.id
+    assert prod.user.username == "alice"
+
+
+@pytest.mark.asyncio
+async def test_select_related_multiple_products(db_setup_and_teardown):
+    user = await User(username="bob", email="bob@ex.com", is_active=True).save()
+    await Product(
+        name="Widget", price=10.0, description="A widget", in_stock=True, user_id=user.id
+    ).save()
+    await Product(
+        name="Gadget", price=20.0, description="A gadget", in_stock=False, user_id=user.id
+    ).save()
+
+    ProductWithUser = Product.select_related("user")
+    products = await ProductWithUser.all()
+    assert len(products) == 2
+    for prod in products:
+        assert hasattr(prod, "user")
+        assert isinstance(prod.user, User)
+        assert prod.user.id == user.id


### PR DESCRIPTION
Implements the core read/eager-loading ORM features (closes #25) and brings the docs in line with the real API.

## Features
- **`filter()`** with Django-style lookups: `gt, lt, gte, lte, ne, eq, in` (AND-combined).
- **`select_related(*fields)`** — eager-loads forward FK relations with a single SQL `JOIN` and hydrates the related instance.
- **`load_related(*fields)`** — batched eager loading that avoids N+1: one query per relation, stitched in Python. Works for forward FKs, reverse relations, and nested paths (`"product__user"`). Related models are resolved from **type annotations** (no name-guessing), so plural/reverse relations resolve correctly.
- **`TimestampedModel`** base with `created_at` / `updated_at`.
- `model_real_fields` / `model_virtual_fields` split so relation fields are excluded from table DDL and inserts; shared `_camel_to_snake` helper.

## Docs
- README + `docs/USAGE.md` actualized: removed the no-op `Field(pk=True)` (documented `Meta.primary_key`), corrected relationship/instance examples to the FK-column + virtual-relation pattern, documented eager loading and filter lookups.

## Tests
39 passing (Postgres), including `select_related`, `load_related`, and filter-operator coverage. ruff + mypy clean.

> Note: a broader architecture roadmap (chainable QuerySet, dialect/SQL-builder to fix MySQL, explicit relationship system, SQLite, migrations) is tracked in milestones **Epic A–H**; this PR is the foundation those build on.