### PR TITLE
Epic A (1/2): SQL dialect + compiler foundation, adopted in models.py

### DIFF
--- a/riverorm/sql/__init__.py
+++ b/riverorm/sql/__init__.py
@@ -1,0 +1,22 @@
+"""Dialect-agnostic SQL building for RiverORM.
+
+This package provides a clean seam between *describing* a query (the frozen
+dataclasses in :mod:`riverorm.sql.query`) and *rendering* it to a concrete SQL
+string for a particular database (:class:`~riverorm.sql.dialect.Dialect` plus
+:class:`~riverorm.sql.compiler.Compiler`).
+
+It is intentionally pure: no database connections, no I/O.
+"""
+
+from .compiler import Compiler as Compiler
+from .dialect import Dialect as Dialect
+from .dialect import PostgresDialect as PostgresDialect
+from .query import Column as Column
+from .query import Condition as Condition
+from .query import DeleteQuery as DeleteQuery
+from .query import InsertQuery as InsertQuery
+from .query import Join as Join
+from .query import Operator as Operator
+from .query import OrderBy as OrderBy
+from .query import SelectQuery as SelectQuery
+from .query import UpdateQuery as UpdateQuery

--- a/riverorm/sql/compiler.py
+++ b/riverorm/sql/compiler.py
@@ -1,0 +1,122 @@
+"""Render dialect-independent query dataclasses to ``(sql, params)``.
+
+The :class:`Compiler` is dialect-agnostic: every identifier passes through
+``dialect.quote()`` and every value becomes a positional parameter rendered via
+``dialect.placeholder(i)``. Swapping the :class:`~riverorm.sql.dialect.Dialect`
+is the only thing needed to target a different database.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .dialect import Dialect
+from .query import (
+    Column,
+    Condition,
+    DeleteQuery,
+    InsertQuery,
+    Operator,
+    SelectQuery,
+    UpdateQuery,
+)
+
+
+class Compiler:
+    """Compile query dataclasses into SQL strings + positional params."""
+
+    def __init__(self, dialect: Dialect) -> None:
+        self.dialect = dialect
+
+    # -- public API ---------------------------------------------------------
+
+    def compile_select(self, query: SelectQuery) -> tuple[str, list[Any]]:
+        params: list[Any] = []
+        columns = (
+            ", ".join(self._render_column(c, projection=True) for c in query.columns)
+            if query.columns
+            else "*"
+        )
+        table = self.dialect.quote(query.table)
+        if query.table_alias:
+            table = f"{table} AS {self.dialect.quote(query.table_alias)}"
+
+        sql = f"SELECT {columns} FROM {table}"
+
+        for join in query.joins:
+            sql += (
+                f" LEFT JOIN {self.dialect.quote(join.table)}"
+                f" AS {self.dialect.quote(join.alias)}"
+                f" ON {self.dialect.quote(join.left_table)}.{self.dialect.quote(join.left_column)}"
+                f" = {self.dialect.quote(join.alias)}.{self.dialect.quote(join.right_column)}"
+            )
+
+        sql += self._render_where(query.where, params)
+
+        if query.order_by:
+            terms = ", ".join(
+                f"{self._render_column(o.column)} {'DESC' if o.descending else 'ASC'}"
+                for o in query.order_by
+            )
+            sql += f" ORDER BY {terms}"
+        if query.limit is not None:
+            sql += f" LIMIT {query.limit}"
+        if query.offset is not None:
+            sql += f" OFFSET {query.offset}"
+
+        return sql, params
+
+    def compile_insert(self, query: InsertQuery) -> tuple[str, list[Any]]:
+        params: list[Any] = list(query.values)
+        cols = ", ".join(self.dialect.quote(c) for c in query.columns)
+        placeholders = ", ".join(self.dialect.placeholder(i + 1) for i in range(len(query.values)))
+        sql = f"INSERT INTO {self.dialect.quote(query.table)} ({cols}) VALUES ({placeholders})"
+        if query.returning:
+            clause = self.dialect.render_returning(query.returning)
+            if clause:
+                sql += f" {clause}"
+        return sql, params
+
+    def compile_update(self, query: UpdateQuery) -> tuple[str, list[Any]]:
+        params: list[Any] = list(query.values)
+        assignments = ", ".join(
+            f"{self.dialect.quote(col)} = {self.dialect.placeholder(i + 1)}"
+            for i, col in enumerate(query.columns)
+        )
+        sql = f"UPDATE {self.dialect.quote(query.table)} SET {assignments}"
+        sql += self._render_where(query.where, params)
+        return sql, params
+
+    def compile_delete(self, query: DeleteQuery) -> tuple[str, list[Any]]:
+        params: list[Any] = []
+        sql = f"DELETE FROM {self.dialect.quote(query.table)}"
+        sql += self._render_where(query.where, params)
+        return sql, params
+
+    # -- helpers ------------------------------------------------------------
+
+    def _render_column(self, column: Column, projection: bool = False) -> str:
+        ref = self.dialect.quote(column.name)
+        if column.table:
+            ref = f"{self.dialect.quote(column.table)}.{ref}"
+        if projection and column.output_name:
+            ref = f"{ref} AS {self.dialect.quote(column.output_name)}"
+        return ref
+
+    def _render_where(self, where: tuple[Condition, ...], params: list[Any]) -> str:
+        if not where:
+            return ""
+        clauses = [self._render_condition(c, params) for c in where]
+        return " WHERE " + " AND ".join(clauses)
+
+    def _render_condition(self, condition: Condition, params: list[Any]) -> str:
+        col = self._render_column(condition.column)
+        if condition.operator is Operator.IN:
+            values = list(condition.value)
+            placeholders = ", ".join(
+                self.dialect.placeholder(len(params) + i + 1) for i in range(len(values))
+            )
+            params.extend(values)
+            return f"{col} IN ({placeholders})"
+        params.append(condition.value)
+        return f"{col} {condition.operator.value} {self.dialect.placeholder(len(params))}"

--- a/riverorm/sql/dialect.py
+++ b/riverorm/sql/dialect.py
@@ -1,0 +1,115 @@
+"""SQL dialects: per-database syntax rules, kept pure (no DB, no I/O).
+
+A :class:`Dialect` answers the small set of questions that differ between
+databases: how to quote identifiers, how to render positional placeholders, how
+Python types map to column types, how to declare an auto-increment primary key,
+and how new-row primary keys are returned on insert.
+"""
+
+from __future__ import annotations
+
+import types
+import typing
+from abc import ABC, abstractmethod
+
+
+class Dialect(ABC):
+    """Abstract, stateless description of a database's SQL syntax."""
+
+    #: Whether ``INSERT ... RETURNING <pk>`` is supported to fetch generated PKs.
+    supports_returning: bool = False
+
+    @abstractmethod
+    def quote(self, identifier: str) -> str:
+        """Quote an identifier (table/column/alias), escaping embedded quotes."""
+        ...
+
+    @abstractmethod
+    def placeholder(self, index: int) -> str:
+        """Render the positional placeholder for a 1-based parameter ``index``."""
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def python_to_sql_type(annotation: type) -> str:
+        """Map a Python type annotation to this dialect's SQL column type."""
+        ...
+
+    @abstractmethod
+    def auto_increment_pk(self, column: str) -> str:
+        """Render a column definition declaring an auto-increment primary key."""
+        ...
+
+    def render_returning(self, column: str) -> str:
+        """Render a ``RETURNING <column>`` clause for an insert.
+
+        Dialects without ``RETURNING`` support return an empty string.
+        """
+        if not self.supports_returning:
+            return ""
+        return f"RETURNING {self.quote(column)}"
+
+    def boolean_literal(self, value: bool) -> str:
+        """Render a boolean literal (used when inlining, not for params)."""
+        return "TRUE" if value else "FALSE"
+
+
+class PostgresDialect(Dialect):
+    """PostgreSQL syntax: ``"id"`` quoting and ``$1`` placeholders."""
+
+    supports_returning = True
+
+    def quote(self, identifier: str) -> str:
+        escaped = identifier.replace('"', '""')
+        return f'"{escaped}"'
+
+    def placeholder(self, index: int) -> str:
+        if index < 1:
+            raise ValueError("placeholder index is 1-based and must be >= 1")
+        return f"${index}"
+
+    @staticmethod
+    def python_to_sql_type(annotation: type) -> str:
+        # Ported verbatim from PostgresDatabase.python_to_sql_type for parity.
+        py_type: typing.Any = annotation
+
+        # Handle Union types (e.g., Optional[int], int | None).
+        # For PEP 604 (int | None), __origin__ is types.UnionType in Python 3.10+.
+        union_types = (
+            getattr(typing, "Union", None),
+            getattr(types, "UnionType", None),
+        )
+        if (hasattr(py_type, "__origin__") and py_type.__origin__ in union_types) or (
+            hasattr(types, "UnionType") and isinstance(py_type, types.UnionType)
+        ):
+            args = getattr(py_type, "__args__", None)
+            if (
+                args is None
+                and hasattr(py_type, "__origin__")
+                and hasattr(py_type.__origin__, "__args__")
+            ):
+                args = py_type.__origin__.__args__
+            if args:
+                py_type = next(t for t in args if t is not type(None))
+
+        if py_type is int:
+            return "INTEGER"
+        elif py_type is float:
+            return "REAL"
+        elif py_type is bool:
+            return "BOOLEAN"
+        elif py_type is str:
+            return "TEXT"
+        elif hasattr(py_type, "__name__") and py_type.__name__ == "datetime":
+            return "TIMESTAMP"
+        elif hasattr(py_type, "__name__") and py_type.__name__ == "date":
+            return "DATE"
+        elif hasattr(py_type, "__name__") and py_type.__name__ == "UUID":
+            return "UUID"
+        elif py_type is list or (hasattr(py_type, "__origin__") and py_type.__origin__ is list):
+            return "JSONB"
+        else:
+            raise TypeError(f"Unsupported Python type for SQL: {py_type}")
+
+    def auto_increment_pk(self, column: str) -> str:
+        return f"{column} SERIAL PRIMARY KEY"

--- a/riverorm/sql/query.py
+++ b/riverorm/sql/query.py
@@ -1,0 +1,128 @@
+"""Dialect-independent description of SQL queries.
+
+These frozen dataclasses describe *what* a query does without committing to any
+particular SQL syntax. A :class:`~riverorm.sql.compiler.Compiler` paired with a
+:class:`~riverorm.sql.dialect.Dialect` turns them into a concrete
+``(sql, params)`` pair.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class Operator(str, Enum):
+    """Comparison operators supported in a :class:`Condition`.
+
+    Mirrors the operators currently understood by ``Model.filter()``.
+    """
+
+    EQ = "="
+    NE = "!="
+    GT = ">"
+    LT = "<"
+    GTE = ">="
+    LTE = "<="
+    IN = "IN"
+
+
+@dataclass(frozen=True)
+class Column:
+    """A reference to a column, optionally qualified by a table/alias.
+
+    When ``alias`` is set the column compiles to ``"alias"."name"``; otherwise it
+    compiles to ``"name"``. ``output_name`` renders an ``AS`` clause in SELECT
+    projections (used for the ``rel__col`` aliases of ``select_related``).
+    """
+
+    name: str
+    table: str | None = None
+    output_name: str | None = None
+
+
+@dataclass(frozen=True)
+class Condition:
+    """A single ``WHERE`` predicate: ``column <operator> value(s)``.
+
+    For :attr:`Operator.IN`, ``value`` must be a sequence; each element becomes a
+    positional parameter. For all other operators ``value`` is a single scalar.
+    """
+
+    column: Column
+    operator: Operator
+    value: Any
+
+
+@dataclass(frozen=True)
+class OrderBy:
+    """An ``ORDER BY`` term."""
+
+    column: Column
+    descending: bool = False
+
+
+@dataclass(frozen=True)
+class Join:
+    """A ``LEFT JOIN`` of ``table`` (aliased as ``alias``) onto the query.
+
+    The join condition is ``left.left_column = right.right_column`` where ``left``
+    is identified by :attr:`left_table` and ``right`` by :attr:`alias`.
+    """
+
+    table: str
+    alias: str
+    left_table: str
+    left_column: str
+    right_column: str
+
+
+@dataclass(frozen=True)
+class SelectQuery:
+    """A ``SELECT`` statement."""
+
+    table: str
+    columns: tuple[Column, ...] = ()
+    table_alias: str | None = None
+    joins: tuple[Join, ...] = ()
+    where: tuple[Condition, ...] = ()
+    order_by: tuple[OrderBy, ...] = ()
+    limit: int | None = None
+    offset: int | None = None
+
+
+@dataclass(frozen=True)
+class InsertQuery:
+    """An ``INSERT`` statement.
+
+    ``columns`` and ``values`` are positionally paired. ``returning`` names a
+    column to render in a ``RETURNING`` clause (Postgres-style) when supported by
+    the dialect.
+    """
+
+    table: str
+    columns: tuple[str, ...]
+    values: tuple[Any, ...]
+    returning: str | None = None
+
+
+@dataclass(frozen=True)
+class UpdateQuery:
+    """An ``UPDATE`` statement.
+
+    ``assignments`` are positionally paired ``column``/``value`` tuples.
+    """
+
+    table: str
+    columns: tuple[str, ...]
+    values: tuple[Any, ...]
+    where: tuple[Condition, ...] = field(default=())
+
+
+@dataclass(frozen=True)
+class DeleteQuery:
+    """A ``DELETE`` statement."""
+
+    table: str
+    where: tuple[Condition, ...] = field(default=())

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,0 +1,188 @@
+"""Pure unit tests for the dialect/compiler SQL foundation.
+
+These tests are deliberately database-free: they exercise only the pure
+dialect + compiler machinery and assert exact ``(sql, params)`` output.
+"""
+
+from datetime import date, datetime
+from uuid import UUID
+
+import pytest
+
+from riverorm.sql import (
+    Column,
+    Compiler,
+    Condition,
+    DeleteQuery,
+    InsertQuery,
+    Join,
+    Operator,
+    OrderBy,
+    PostgresDialect,
+    SelectQuery,
+    UpdateQuery,
+)
+
+
+@pytest.fixture
+def compiler() -> Compiler:
+    return Compiler(PostgresDialect())
+
+
+# -- identifier quoting & placeholders --------------------------------------
+
+
+def test_quote_basic():
+    assert PostgresDialect().quote("users") == '"users"'
+
+
+def test_quote_escapes_embedded_quotes():
+    assert PostgresDialect().quote('we"ird') == '"we""ird"'
+
+
+def test_placeholder_is_one_based():
+    d = PostgresDialect()
+    assert d.placeholder(1) == "$1"
+    assert d.placeholder(3) == "$3"
+
+
+def test_placeholder_rejects_zero():
+    with pytest.raises(ValueError):
+        PostgresDialect().placeholder(0)
+
+
+# -- SELECT ------------------------------------------------------------------
+
+
+def test_select_with_mixed_where_order_limit_offset(compiler: Compiler):
+    query = SelectQuery(
+        table="users",
+        where=(
+            Condition(Column("age"), Operator.GTE, 18),
+            Condition(Column("status"), Operator.NE, "banned"),
+            Condition(Column("id"), Operator.IN, [1, 2, 3]),
+        ),
+        order_by=(OrderBy(Column("created_at"), descending=True),),
+        limit=10,
+        offset=5,
+    )
+    sql, params = compiler.compile_select(query)
+    assert sql == (
+        'SELECT * FROM "users"'
+        ' WHERE "age" >= $1 AND "status" != $2 AND "id" IN ($3, $4, $5)'
+        ' ORDER BY "created_at" DESC'
+        " LIMIT 10 OFFSET 5"
+    )
+    assert params == [18, "banned", 1, 2, 3]
+
+
+def test_select_with_join_projection_and_aliases(compiler: Compiler):
+    query = SelectQuery(
+        table="order",
+        table_alias="order",
+        columns=(
+            Column("id", table="order"),
+            Column("user_id", table="order"),
+            Column("username", table="user", output_name="user__username"),
+        ),
+        joins=(
+            Join(
+                table="user",
+                alias="user",
+                left_table="order",
+                left_column="user_id",
+                right_column="id",
+            ),
+        ),
+    )
+    sql, params = compiler.compile_select(query)
+    assert sql == (
+        'SELECT "order"."id", "order"."user_id",'
+        ' "user"."username" AS "user__username"'
+        ' FROM "order" AS "order"'
+        ' LEFT JOIN "user" AS "user"'
+        ' ON "order"."user_id" = "user"."id"'
+    )
+    assert params == []
+
+
+def test_select_no_where(compiler: Compiler):
+    sql, params = compiler.compile_select(SelectQuery(table="users", limit=1000))
+    assert sql == 'SELECT * FROM "users" LIMIT 1000'
+    assert params == []
+
+
+# -- INSERT ------------------------------------------------------------------
+
+
+def test_insert_with_returning(compiler: Compiler):
+    query = InsertQuery(
+        table="users",
+        columns=("username", "email"),
+        values=("alice", "alice@example.com"),
+        returning="id",
+    )
+    sql, params = compiler.compile_insert(query)
+    assert sql == ('INSERT INTO "users" ("username", "email") VALUES ($1, $2) RETURNING "id"')
+    assert params == ["alice", "alice@example.com"]
+
+
+# -- UPDATE & DELETE ---------------------------------------------------------
+
+
+def test_update_with_where(compiler: Compiler):
+    query = UpdateQuery(
+        table="users",
+        columns=("username", "email"),
+        values=("bob", "bob@example.com"),
+        where=(Condition(Column("id"), Operator.EQ, 7),),
+    )
+    sql, params = compiler.compile_update(query)
+    assert sql == ('UPDATE "users" SET "username" = $1, "email" = $2 WHERE "id" = $3')
+    assert params == ["bob", "bob@example.com", 7]
+
+
+def test_delete_with_where(compiler: Compiler):
+    query = DeleteQuery(
+        table="users",
+        where=(Condition(Column("id"), Operator.EQ, 42),),
+    )
+    sql, params = compiler.compile_delete(query)
+    assert sql == 'DELETE FROM "users" WHERE "id" = $1'
+    assert params == [42]
+
+
+# -- type map & autoincrement ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "annotation,expected",
+    [
+        (int, "INTEGER"),
+        (float, "REAL"),
+        (bool, "BOOLEAN"),
+        (str, "TEXT"),
+        (datetime, "TIMESTAMP"),
+        (date, "DATE"),
+        (UUID, "UUID"),
+        (list, "JSONB"),
+        (list[int], "JSONB"),
+        (int | None, "INTEGER"),
+        (str | None, "TEXT"),
+    ],
+)
+def test_postgres_type_map(annotation, expected):
+    assert PostgresDialect.python_to_sql_type(annotation) == expected
+
+
+def test_postgres_type_map_rejects_unknown():
+    with pytest.raises(TypeError):
+        PostgresDialect.python_to_sql_type(object)
+
+
+def test_postgres_autoincrement_pk():
+    assert PostgresDialect().auto_increment_pk("id") == "id SERIAL PRIMARY KEY"
+
+
+def test_supports_returning_flag():
+    assert PostgresDialect().supports_returning is True


### PR DESCRIPTION
First half of **Epic A — Dialect & SQL-builder foundation**. Purely internal; no public API or behavior change (Postgres output is identical apart from now-quoted identifiers, which is SQL-equivalent).

## What
- **`riverorm/sql/`** (new, #79 #80): a stateless `Dialect` ABC + `PostgresDialect`, frozen query dataclasses (`SelectQuery/InsertQuery/UpdateQuery/DeleteQuery`, `Condition`, `Join`, `Column`), and a dialect-agnostic `Compiler` that renders `(sql, params)`. Every identifier passes through `dialect.quote()`; values become positional params.
- **`models.py` refactor** (#81): `save/delete/all/get/filter/select_related/create_table/drop_table` now build query dataclasses and compile them instead of hand-writing SQL with `$N` placeholders. Drivers expose a `dialect` property (`PostgresDialect` today; MySQL raises `NotImplementedError` until the next PR).

## Why
This is the seam that lets one codebase emit correct SQL per backend. It unblocks the **MySQL placeholder bug fix** (next PR: `MySQLDialect` + enabling MySQL in the test matrix) and later SQLite, with no scattered SQL strings.

## Tests
63 passing (39 ORM tests on Postgres + 24 new DB-free `tests/test_sql.py` compiler/dialect unit tests). ruff + mypy clean.

Part of milestone **Epic A**. Follow-up: A4 `MySQLDialect` + A5 enable MySQL matrix (+ A6 strip driver SQL-sniffing).