### PR TITLE
Epic A (2/2): MySQL dialect + matrix, strip driver SQL-sniffing

### DIFF
--- a/riverorm/db/base.py
+++ b/riverorm/db/base.py
@@ -1,12 +1,25 @@
 from abc import ABC, abstractmethod
 from typing import Any, Sequence
 
+from riverorm.sql import Compiler, Dialect
+
 
 class BaseDatabase(ABC):
     is_connected: bool = False
 
     @abstractmethod
     def __init__(self, dsn: str, debug: bool = False) -> None: ...
+
+    @property
+    @abstractmethod
+    def dialect(self) -> Dialect:
+        """Return the SQL dialect describing this backend's syntax."""
+        ...
+
+    @property
+    def compiler(self) -> Compiler:
+        """A :class:`Compiler` bound to this backend's :attr:`dialect`."""
+        return Compiler(self.dialect)
 
     @abstractmethod
     async def connect(self) -> None: ...
@@ -26,14 +39,12 @@ class BaseDatabase(ABC):
     @abstractmethod
     async def update(self, query: str, *args: Any) -> Any: ...
 
-    @staticmethod
     @abstractmethod
-    def python_to_sql_type(py_type: type) -> str: ...
+    async def execute_insert(self, query: str, *args: Any) -> Any:
+        """Execute an ``INSERT`` and return the generated primary key.
 
-    # Helper methods for SQL generation
-
-    @staticmethod
-    @abstractmethod
-    def auto_increment_primary_key_sql(name: str) -> str:
-        """Return the SQL snippet for an auto-increment primary key field."""
+        Used for backends without ``RETURNING`` support: the value comes from
+        the driver after the insert (e.g. ``cursor.lastrowid``). Assumes a single
+        integer auto-increment primary key.
+        """
         ...

--- a/riverorm/db/mysql.py
+++ b/riverorm/db/mysql.py
@@ -81,10 +81,8 @@ class MySQLDatabase(BaseDatabase):
     async def fetch(self, query: str, *args):
         if self._conn is None:
             raise Exception("Connection is not established")
-        if not query.strip().lower().startswith("select"):
-            raise ValueError("Fetch can only be used with SELECT queries")
-        if not query.strip().endswith(";"):
-            query += ";"
+        if self._debug:
+            logger.debug(f"SQL: {query} - {args}")
         async with self._conn.cursor(aiomysql.DictCursor) as cursor:
             await cursor.execute(query, args)
             return await cursor.fetchall()
@@ -92,10 +90,8 @@ class MySQLDatabase(BaseDatabase):
     async def fetchrow(self, query: str, *args):
         if self._conn is None:
             raise Exception("Connection is not established")
-        if not query.strip().lower().startswith("select"):
-            raise ValueError("Fetchrow can only be used with SELECT queries")
-        if not query.strip().endswith(";"):
-            query += ";"
+        if self._debug:
+            logger.debug(f"SQL: {query} - {args}")
         async with self._conn.cursor(aiomysql.DictCursor) as cursor:
             await cursor.execute(query, args)
             return await cursor.fetchone()
@@ -103,10 +99,8 @@ class MySQLDatabase(BaseDatabase):
     async def update(self, query: str, *args):
         if self._conn is None:
             raise Exception("Connection is not established")
-        if not query.strip().lower().startswith("update"):
-            raise ValueError("Update can only be used with UPDATE queries")
-        if not query.strip().endswith(";"):
-            query += ";"
+        if self._debug:
+            logger.debug(f"SQL: {query} - {args}")
         async with self._conn.cursor() as cursor:
             await cursor.execute(query, args)
             return cursor.rowcount

--- a/riverorm/db/mysql.py
+++ b/riverorm/db/mysql.py
@@ -2,6 +2,8 @@ import logging
 
 import aiomysql
 
+from riverorm.sql import Dialect, MySQLDialect
+
 from .base import BaseDatabase
 
 logger = logging.getLogger(__name__)
@@ -11,6 +13,7 @@ class MySQLDatabase(BaseDatabase):
     _conn: aiomysql.Connection | None
     _debug: bool
     _dsn: str
+    _dialect: Dialect = MySQLDialect()
 
     def __init__(self, dsn: str, debug: bool = False):
         self._conn = None
@@ -20,6 +23,10 @@ class MySQLDatabase(BaseDatabase):
             logger.setLevel(logging.DEBUG)
         else:
             logger.setLevel(logging.INFO)
+
+    @property
+    def dialect(self) -> Dialect:
+        return self._dialect
 
     def dsn_to_dict(self, dsn: str) -> dict:
         """Convert DSN string (RFC 1738 style) to a dictionary for aiomysql.connect."""
@@ -51,7 +58,9 @@ class MySQLDatabase(BaseDatabase):
         return dct
 
     async def connect(self) -> None:
-        self._conn = await aiomysql.connect(**self.dsn_to_dict(self._dsn))
+        # autocommit so writes/DDL persist without explicit transaction handling,
+        # matching asyncpg's default behaviour.
+        self._conn = await aiomysql.connect(autocommit=True, **self.dsn_to_dict(self._dsn))
         self.is_connected = True
 
     async def close(self) -> None:
@@ -102,21 +111,16 @@ class MySQLDatabase(BaseDatabase):
             await cursor.execute(query, args)
             return cursor.rowcount
 
-    @staticmethod
-    def python_to_sql_type(py_type: type) -> str:
-        if py_type is int:
-            return "INT"
-        elif py_type is float:
-            return "FLOAT"
-        elif py_type is str:
-            return "VARCHAR(255)"
-        elif py_type is bool:
-            return "BOOLEAN"
-        elif py_type is bytes:
-            return "BLOB"
-        else:
-            raise ValueError(f"Unsupported type: {py_type}")
+    async def execute_insert(self, query: str, *args):
+        """Run an ``INSERT`` and return the auto-increment PK via ``lastrowid``.
 
-    @staticmethod
-    def auto_increment_primary_key_sql(name: str) -> str:
-        return f"{name} INTEGER PRIMARY KEY AUTO_INCREMENT"
+        MySQL has no ``RETURNING`` clause; the generated primary key is taken
+        from ``cursor.lastrowid``. Assumes a single integer auto-increment PK.
+        """
+        if self._conn is None:
+            raise Exception("Connection is not established")
+        if self._debug:
+            logger.debug(f"SQL: {query} - {args}")
+        async with self._conn.cursor() as cursor:
+            await cursor.execute(query, args)
+            return cursor.lastrowid

--- a/riverorm/db/postgres.py
+++ b/riverorm/db/postgres.py
@@ -1,8 +1,8 @@
 import logging
-import types
-import typing
 
 import asyncpg
+
+from riverorm.sql import Dialect, PostgresDialect
 
 from .base import BaseDatabase
 
@@ -13,6 +13,7 @@ class PostgresDatabase(BaseDatabase):
     _conn: asyncpg.Connection | None
     _debug: bool
     _dsn: str
+    _dialect: Dialect = PostgresDialect()
 
     def __init__(self, dsn: str, debug: bool = False):
         self._conn = None
@@ -22,6 +23,10 @@ class PostgresDatabase(BaseDatabase):
             logger.setLevel(logging.DEBUG)
         else:
             logger.setLevel(logging.INFO)
+
+    @property
+    def dialect(self) -> Dialect:
+        return self._dialect
 
     async def connect(self) -> None:
         self._conn = await asyncpg.connect(self._dsn)
@@ -71,59 +76,15 @@ class PostgresDatabase(BaseDatabase):
             query += ";"
         return await self._conn.execute(query, *args)
 
-    @staticmethod
-    def python_to_sql_type(py_type: type) -> str:
-        # Handle Union types (e.g., Optional[int], int | None)
+    async def execute_insert(self, query: str, *args):
+        """Run an ``INSERT ... RETURNING`` and return the generated PK value.
 
-        # For PEP 604 (int | None), __origin__ is types.UnionType in Python 3.10+
-        union_types = (
-            getattr(typing, "Union", None),
-            getattr(types, "UnionType", None),
-        )
-        # Handle typing.Union and PEP 604 unions
-        if (hasattr(py_type, "__origin__") and py_type.__origin__ in union_types) or (
-            hasattr(types, "UnionType") and isinstance(py_type, types.UnionType)
-        ):
-            # Get the first non-None type from the union
-            args = getattr(py_type, "__args__", None)
-            if args is None:
-                args = py_type.__args__ if hasattr(py_type, "__args__") else None
-            if (
-                args is None
-                and hasattr(py_type, "__origin__")
-                and hasattr(py_type.__origin__, "__args__")
-            ):
-                args = py_type.__origin__.__args__
-            if args is None:
-                # For PEP 604, __args__ is available
-                args = getattr(py_type, "__args__", None)
-            if args:
-                py_type = next(t for t in args if t is not type(None))
-
-        if py_type is int:
-            return "INTEGER"
-        elif py_type is float:
-            return "REAL"
-        elif py_type is bool:
-            return "BOOLEAN"
-        elif py_type is str:
-            return "TEXT"
-        elif hasattr(py_type, "__name__") and py_type.__name__ == "datetime":
-            return "TIMESTAMP"
-        elif hasattr(py_type, "__name__") and py_type.__name__ == "date":
-            return "DATE"
-        elif hasattr(py_type, "__name__") and py_type.__name__ == "UUID":
-            return "UUID"
-        elif (
-            py_type is list
-            or (hasattr(py_type, "__origin__") and py_type.__origin__ is list)
-            or (hasattr(py_type, "__origin__") and py_type.__origin__ is typing.List)
-        ):
-            # For list types, use JSONB in PostgreSQL
-            return "JSONB"
-        else:
-            raise TypeError(f"Unsupported Python type for SQL: {py_type}")
-
-    @staticmethod
-    def auto_increment_primary_key_sql(name: str) -> str:
-        return f"{name} SERIAL PRIMARY KEY"
+        Postgres supports ``RETURNING``, so the caller is expected to append a
+        ``RETURNING`` clause; the first returned column is the new primary key.
+        """
+        if self._conn is None:
+            raise Exception("Connection is not established")
+        if self._debug:
+            logger.debug(f"SQL: {query} - {args}")
+        row = await self._conn.fetchrow(query, *args)
+        return next(iter(row.values())) if row else None

--- a/riverorm/db/postgres.py
+++ b/riverorm/db/postgres.py
@@ -48,32 +48,22 @@ class PostgresDatabase(BaseDatabase):
     async def fetch(self, query: str, *args):
         if self._conn is None:
             raise Exception("Connection is not established")
-        if not query.strip().lower().startswith("select"):
-            raise ValueError("Fetch can only be used with SELECT queries")
-        if not query.strip().endswith(";"):
-            query += ";"
+        if self._debug:
+            logger.debug(f"SQL: {query} - {args}")
         return await self._conn.fetch(query, *args)
 
     async def fetchrow(self, query: str, *args):
         if self._conn is None:
             raise Exception("Connection is not established")
-        # Allow SELECT and INSERT ... RETURNING queries
-        q = query.strip().lower()
-        if not (q.startswith("select") or (q.startswith("insert") and "returning" in q)):
-            raise ValueError(
-                "Fetchrow can only be used with SELECT or INSERT ... RETURNING queries"
-            )
-        if not query.strip().endswith(";"):
-            query += ";"
+        if self._debug:
+            logger.debug(f"SQL: {query} - {args}")
         return await self._conn.fetchrow(query, *args)
 
     async def update(self, query: str, *args):
         if self._conn is None:
             raise Exception("Connection is not established")
-        if not query.strip().lower().startswith("update"):
-            raise ValueError("Update can only be used with UPDATE queries")
-        if not query.strip().endswith(";"):
-            query += ";"
+        if self._debug:
+            logger.debug(f"SQL: {query} - {args}")
         return await self._conn.execute(query, *args)
 
     async def execute_insert(self, query: str, *args):

--- a/riverorm/models.py
+++ b/riverorm/models.py
@@ -8,6 +8,16 @@ from pydantic.fields import FieldInfo
 
 from riverorm import constants
 from riverorm.db import BaseDatabase, DatabaseRegistry
+from riverorm.sql import (
+    Column,
+    Condition,
+    DeleteQuery,
+    InsertQuery,
+    Join,
+    Operator,
+    SelectQuery,
+    UpdateQuery,
+)
 from riverorm.utils import is_int_type
 
 T = TypeVar("T", bound="Model")
@@ -129,56 +139,114 @@ class Model(BaseModel):
             name: field for name, field in cls.model_fields.items() if name not in virtual_fields
         }
 
+    @classmethod
+    def _conditions_from_kwargs(cls, kwargs: dict[str, Any]) -> tuple[Condition, ...]:
+        """Translate Django-style ``field__op=value`` kwargs into ``Condition``s."""
+        ops = {
+            "gt": Operator.GT,
+            "lt": Operator.LT,
+            "gte": Operator.GTE,
+            "lte": Operator.LTE,
+            "ne": Operator.NE,
+            "eq": Operator.EQ,
+            "in": Operator.IN,
+        }
+        conditions: list[Condition] = []
+        for key, value in kwargs.items():
+            if "__" in key:
+                field, op = key.rsplit("__", 1)
+                operator = ops.get(op)
+                if operator is None:
+                    raise ValueError(f"Unsupported filter operator: {op}")
+                if operator is Operator.IN:
+                    assert isinstance(value, (list, tuple)), (
+                        "__in operator requires a list or tuple"
+                    )
+            else:
+                field, operator = key, Operator.EQ
+            conditions.append(Condition(Column(field), operator, value))
+        return tuple(conditions)
+
     async def save(self):
         """Save the model instance to the database, with auto-increment PK support."""
+        db = self.db()
+        compiler = db.compiler
         fields = list(self.__class__.model_real_fields().keys())
         pk_name = self.Meta.primary_key
         pk = getattr(self, pk_name, None)
 
         if pk is None:
-            # INSERT: omit PK if None, let DB auto-generate
+            # INSERT: omit PK if None, let DB auto-generate it.
             insert_fields = [f for f in fields if not (f == pk_name and getattr(self, f) is None)]
-            values = [getattr(self, f) for f in insert_fields]
-            cols = ", ".join(insert_fields)
-            placeholders = ", ".join(f"${i + 1}" for i in range(len(insert_fields)))
-            # Use RETURNING to fetch the generated PK
-            query = (
-                f'INSERT INTO "{self.table_name()}" ({cols}) VALUES ({placeholders}) '
-                f"RETURNING {pk_name}"
-            )
-            row = await self.db().fetchrow(query, *values)
-            if row and pk_name in row:
-                setattr(self, pk_name, row[pk_name])
+            values = tuple(getattr(self, f) for f in insert_fields)
+            if db.dialect.supports_returning:
+                query = InsertQuery(
+                    table=self.table_name(),
+                    columns=tuple(insert_fields),
+                    values=values,
+                    returning=pk_name,
+                )
+                sql, params = compiler.compile_insert(query)
+                row = await db.fetchrow(sql, *params)
+                if row and pk_name in row:
+                    setattr(self, pk_name, row[pk_name])
+            else:
+                # No RETURNING (e.g. MySQL): read the generated PK from the driver
+                # (cursor.lastrowid). Assumes a single int auto-increment PK.
+                query = InsertQuery(
+                    table=self.table_name(),
+                    columns=tuple(insert_fields),
+                    values=values,
+                    returning=None,
+                )
+                sql, params = compiler.compile_insert(query)
+                new_pk = await db.execute_insert(sql, *params)
+                if new_pk is not None:
+                    setattr(self, pk_name, new_pk)
         else:
             # UPDATE
-            values = [getattr(self, f) for f in fields]
-            cols = ", ".join(f"{f} = ${i + 1}" for i, f in enumerate(fields))
-            query = f'UPDATE "{self.table_name()}" SET {cols} WHERE {pk_name} = ${len(fields) + 1}'
-            values.append(pk)
-            await self.db().update(query, *values)
-        # TODO: Update the instance with the new values from the database
+            values = tuple(getattr(self, f) for f in fields)
+            update = UpdateQuery(
+                table=self.table_name(),
+                columns=tuple(fields),
+                values=values,
+                where=(Condition(Column(pk_name), Operator.EQ, pk),),
+            )
+            sql, params = compiler.compile_update(update)
+            await db.update(sql, *params)
         return self
 
     async def delete(self):
-        pk_value = getattr(self, self.Meta.primary_key)
-        query = f'DELETE FROM "{self.table_name()}" WHERE {self.Meta.primary_key} = $1'
-        await self.db().execute(query, pk_value)
+        pk_name = self.Meta.primary_key
+        pk_value = getattr(self, pk_name)
+        db = self.db()
+        delete = DeleteQuery(
+            table=self.table_name(),
+            where=(Condition(Column(pk_name), Operator.EQ, pk_value),),
+        )
+        sql, params = db.compiler.compile_delete(delete)
+        await db.execute(sql, *params)
 
     @classmethod
     async def all(cls: type[T], limit: int = 1000) -> list[T]:
         """Fetch all rows for this model (up to the given limit)."""
-        query = f'SELECT * FROM "{cls.table_name()}" LIMIT {limit};'
-        rows = await cls.db().fetch(query)
+        db = cls.db()
+        query = SelectQuery(table=cls.table_name(), limit=limit)
+        sql, params = db.compiler.compile_select(query)
+        rows = await db.fetch(sql, *params)
         return [cls(**dict(row)) for row in rows]
 
     @classmethod
     async def get(cls: type[T], **kwargs) -> T | None:
-        keys = list(kwargs.keys())
-        values = list(kwargs.values())
-        conditions = " AND ".join(f"{k} = ${i + 1}" for i, k in enumerate(keys))
-        query = f'SELECT * FROM "{cls.table_name()}" WHERE {conditions} LIMIT 1'
-        row = await cls.db().fetchrow(query, *values)
-        return cls(**row) if row else None
+        db = cls.db()
+        query = SelectQuery(
+            table=cls.table_name(),
+            where=cls._conditions_from_kwargs(kwargs),
+            limit=1,
+        )
+        sql, params = db.compiler.compile_select(query)
+        row = await db.fetchrow(sql, *params)
+        return cls(**dict(row)) if row else None
 
     @classmethod
     async def filter(cls: type[T], **kwargs) -> list[T]:
@@ -186,43 +254,13 @@ class Model(BaseModel):
         Filter rows using field lookups, e.g. age__gt=18, name="foo".
         Supported operators: __gt, __lt, __gte, __lte, __ne, __eq (default), __in
         """
-        ops = {
-            "gt": ">",
-            "lt": "<",
-            "gte": ">=",
-            "lte": "<=",
-            "ne": "!=",
-            "eq": "=",
-            "in": "IN",
-        }
-        conditions = []
-        values: list = []
-        param_idx = 1
-        for key, value in kwargs.items():
-            if "__" in key:
-                field, op = key.rsplit("__", 1)
-                sql_op = ops.get(op)
-                if not sql_op:
-                    raise ValueError(f"Unsupported filter operator: {op}")
-                if op == "in":
-                    assert isinstance(value, (list, tuple)), (
-                        "__in operator requires a list or tuple"
-                    )
-                    placeholders = ", ".join(f"${param_idx + i}" for i in range(len(value)))
-                    conditions.append(f"{field} IN ({placeholders})")
-                    values.extend(value)
-                    param_idx += len(value)
-                else:
-                    conditions.append(f"{field} {sql_op} ${param_idx}")
-                    values.append(value)
-                    param_idx += 1
-            else:
-                conditions.append(f"{key} = ${param_idx}")
-                values.append(value)
-                param_idx += 1
-        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
-        query = f'SELECT * FROM "{cls.table_name()}"{where}'
-        rows = await cls.db().fetch(query, *values)
+        db = cls.db()
+        query = SelectQuery(
+            table=cls.table_name(),
+            where=cls._conditions_from_kwargs(kwargs),
+        )
+        sql, params = db.compiler.compile_select(query)
+        rows = await db.fetch(sql, *params)
         return [cls(**dict(r)) for r in rows]
 
     @classmethod
@@ -247,58 +285,58 @@ class Model(BaseModel):
                 raise ValueError(f"Related model class for '{rel}' not found in module {mod}")
             rel_map[rel] = (fk_field, related_model)
 
-        async def all(cls, limit: int = 1000):
+        def _build_columns_and_joins() -> tuple[tuple[Column, ...], tuple[Join, ...]]:
             base_alias = base_table
-            select_cols = [f'"{base_alias}"."{f}"' for f in model_fields.keys()]
-            join_clauses = []
+            columns: list[Column] = [Column(name=f, table=base_alias) for f in model_fields.keys()]
+            joins: list[Join] = []
             for rel, (fk_field, related_model) in rel_map.items():
                 rel_table = related_model.table_name()
                 rel_alias = rel_table
-                rel_cols = [
-                    f'"{rel_alias}"."{col}" AS {rel}__{col}'
+                columns.extend(
+                    Column(name=col, table=rel_alias, output_name=f"{rel}__{col}")
                     for col in related_model.model_real_fields().keys()
-                ]
-                select_cols.extend(rel_cols)
-                join_clauses.append(
-                    f'LEFT JOIN "{rel_table}" AS "{rel_alias}" '
-                    f'ON "{base_alias}"."{fk_field}" = "{rel_alias}"."id"'
                 )
-            select_sql = ", ".join(select_cols)
-            joins = " ".join(join_clauses)
-            query = (
-                f'SELECT {select_sql} FROM "{base_table}" AS "{base_alias}" {joins} LIMIT {limit};'
+                joins.append(
+                    Join(
+                        table=rel_table,
+                        alias=rel_alias,
+                        left_table=base_alias,
+                        left_column=fk_field,
+                        right_column="id",
+                    )
+                )
+            return tuple(columns), tuple(joins)
+
+        async def all(cls, limit: int = 1000):
+            db = cls.db()
+            columns, joins = _build_columns_and_joins()
+            query = SelectQuery(
+                table=base_table,
+                table_alias=base_table,
+                columns=columns,
+                joins=joins,
+                limit=limit,
             )
-            rows = await cls.db().fetch(query)
+            sql, params = db.compiler.compile_select(query)
+            rows = await db.fetch(sql, *params)
             return [cls._hydrate_with_related(row) for row in rows]
 
         async def filter(cls, **kwargs):
-            base_alias = base_table
-            select_cols = [f'"{base_alias}"."{f}"' for f in model_fields.keys()]
-            join_clauses = []
-            for rel, (fk_field, related_model) in rel_map.items():
-                rel_table = related_model.table_name()
-                rel_alias = rel_table
-                rel_cols = [
-                    f'"{rel_alias}"."{col}" AS {rel}__{col}'
-                    for col in related_model.model_real_fields().keys()
-                ]
-                select_cols.extend(rel_cols)
-                join_clauses.append(
-                    f'LEFT JOIN "{rel_table}" AS "{rel_alias}" '
-                    f'ON "{base_alias}"."{fk_field}" = "{rel_alias}"."id"'
-                )
-            select_sql = ", ".join(select_cols)
-            joins = " ".join(join_clauses)
-            conditions = []
-            values = []
-            param_idx = 1
-            for key, value in kwargs.items():
-                conditions.append(f'"{base_alias}"."{key}" = ${param_idx}')
-                values.append(value)
-                param_idx += 1
-            where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
-            query = f'SELECT {select_sql} FROM "{base_table}" AS "{base_alias}" {joins}{where};'
-            rows = await cls.db().fetch(query, *values)
+            db = cls.db()
+            columns, joins = _build_columns_and_joins()
+            where = tuple(
+                Condition(Column(key, table=base_table), Operator.EQ, value)
+                for key, value in kwargs.items()
+            )
+            query = SelectQuery(
+                table=base_table,
+                table_alias=base_table,
+                columns=columns,
+                joins=joins,
+                where=where,
+            )
+            sql, params = db.compiler.compile_select(query)
+            rows = await db.fetch(sql, *params)
             return [cls._hydrate_with_related(row) for row in rows]
 
         def _hydrate_with_related(cls, row):
@@ -429,6 +467,7 @@ class Model(BaseModel):
     @classmethod
     async def create_table(cls: type[T]):
         db = cls.db()
+        dialect = db.dialect
         parts = []
         pk_name = getattr(cls.Meta, "primary_key", constants.DEFAULT_PRIMARY_KEY)
         for name, field in cls.model_real_fields().items():
@@ -437,17 +476,17 @@ class Model(BaseModel):
                 raise ValueError(f"Field '{name}' has no type annotation")
 
             if name == pk_name and is_int_type(field_type):
-                # Delegate to db backend for auto-increment PK SQL
-                parts.append(db.auto_increment_primary_key_sql(name))
+                parts.append(dialect.auto_increment_pk(name))
             else:
-                db_field_type = db.python_to_sql_type(field_type)
-                parts.append(f"{name} {db_field_type}")
-        sql = f'CREATE TABLE IF NOT EXISTS "{cls.table_name()}" ({", ".join(parts)});'
+                db_field_type = dialect.python_to_sql_type(field_type)
+                parts.append(f"{dialect.quote(name)} {db_field_type}")
+        sql = f"CREATE TABLE IF NOT EXISTS {dialect.quote(cls.table_name())} ({', '.join(parts)});"
         return await db.execute(sql)
 
     @classmethod
     async def drop_table(cls: type[T]):
-        sql = f'DROP TABLE IF EXISTS "{cls.table_name()}";'
+        dialect = cls.db().dialect
+        sql = f"DROP TABLE IF EXISTS {dialect.quote(cls.table_name())};"
         return await cls.db().execute(sql)
 
 

--- a/riverorm/sql/__init__.py
+++ b/riverorm/sql/__init__.py
@@ -10,6 +10,7 @@ It is intentionally pure: no database connections, no I/O.
 
 from .compiler import Compiler as Compiler
 from .dialect import Dialect as Dialect
+from .dialect import MySQLDialect as MySQLDialect
 from .dialect import PostgresDialect as PostgresDialect
 from .query import Column as Column
 from .query import Condition as Condition

--- a/riverorm/sql/dialect.py
+++ b/riverorm/sql/dialect.py
@@ -112,4 +112,73 @@ class PostgresDialect(Dialect):
             raise TypeError(f"Unsupported Python type for SQL: {py_type}")
 
     def auto_increment_pk(self, column: str) -> str:
-        return f"{column} SERIAL PRIMARY KEY"
+        return f"{self.quote(column)} SERIAL PRIMARY KEY"
+
+
+class MySQLDialect(Dialect):
+    """MySQL syntax: backtick quoting and ``%s`` placeholders.
+
+    MySQL/aiomysql uses the ``format`` paramstyle, so every positional parameter
+    is rendered as ``%s`` regardless of its index. There is no ``RETURNING``
+    clause; generated primary keys are read from ``cursor.lastrowid`` instead
+    (see :meth:`riverorm.db.mysql.MySQLDatabase.execute_insert`).
+    """
+
+    supports_returning = False
+
+    def quote(self, identifier: str) -> str:
+        escaped = identifier.replace("`", "``")
+        return f"`{escaped}`"
+
+    def placeholder(self, index: int) -> str:
+        # aiomysql's paramstyle is ``format``; placeholders are positional by
+        # order, not by index, so the index is intentionally ignored.
+        return "%s"
+
+    @staticmethod
+    def python_to_sql_type(annotation: type) -> str:
+        py_type: typing.Any = annotation
+
+        # Unwrap Union/Optional (``int | None``) to the first non-None member,
+        # mirroring :meth:`PostgresDialect.python_to_sql_type`.
+        union_types = (
+            getattr(typing, "Union", None),
+            getattr(types, "UnionType", None),
+        )
+        if (hasattr(py_type, "__origin__") and py_type.__origin__ in union_types) or (
+            hasattr(types, "UnionType") and isinstance(py_type, types.UnionType)
+        ):
+            args = getattr(py_type, "__args__", None)
+            if (
+                args is None
+                and hasattr(py_type, "__origin__")
+                and hasattr(py_type.__origin__, "__args__")
+            ):
+                args = py_type.__origin__.__args__
+            if args:
+                py_type = next(t for t in args if t is not type(None))
+
+        if py_type is bool:
+            # Check bool before int (bool is a subclass of int). BOOLEAN is a
+            # MySQL synonym for TINYINT(1) but avoids the deprecated explicit
+            # integer display width.
+            return "BOOLEAN"
+        elif py_type is int:
+            return "INT"
+        elif py_type is float:
+            return "DOUBLE"
+        elif py_type is str:
+            return "TEXT"
+        elif hasattr(py_type, "__name__") and py_type.__name__ == "datetime":
+            return "DATETIME"
+        elif hasattr(py_type, "__name__") and py_type.__name__ == "date":
+            return "DATE"
+        elif hasattr(py_type, "__name__") and py_type.__name__ == "UUID":
+            return "CHAR(36)"
+        elif py_type is list or (hasattr(py_type, "__origin__") and py_type.__origin__ is list):
+            return "JSON"
+        else:
+            raise TypeError(f"Unsupported Python type for SQL: {py_type}")
+
+    def auto_increment_pk(self, column: str) -> str:
+        return f"{self.quote(column)} INT AUTO_INCREMENT PRIMARY KEY"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from riverorm.db import DatabaseRegistry, MySQLDatabase, PostgresDatabase
 from tests.models import Order, Product, User
 
 
-@pytest.fixture(scope="session", params=[constants.POSTGRES])  # TODO: Add constants.MYSQL
+@pytest.fixture(scope="session", params=[constants.POSTGRES, constants.MYSQL])
 def db_type(request: pytest.FixtureRequest) -> str:
     return str(request.param)
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -16,6 +16,7 @@ from riverorm.sql import (
     DeleteQuery,
     InsertQuery,
     Join,
+    MySQLDialect,
     Operator,
     OrderBy,
     PostgresDialect,
@@ -181,8 +182,73 @@ def test_postgres_type_map_rejects_unknown():
 
 
 def test_postgres_autoincrement_pk():
-    assert PostgresDialect().auto_increment_pk("id") == "id SERIAL PRIMARY KEY"
+    assert PostgresDialect().auto_increment_pk("id") == '"id" SERIAL PRIMARY KEY'
 
 
 def test_supports_returning_flag():
     assert PostgresDialect().supports_returning is True
+
+
+# -- MySQL dialect -----------------------------------------------------------
+
+
+def test_mysql_quote_basic():
+    assert MySQLDialect().quote("users") == "`users`"
+
+
+def test_mysql_quote_escapes_embedded_backticks():
+    assert MySQLDialect().quote("we`ird") == "`we``ird`"
+
+
+def test_mysql_placeholder_is_format_style():
+    d = MySQLDialect()
+    assert d.placeholder(1) == "%s"
+    assert d.placeholder(7) == "%s"
+
+
+@pytest.mark.parametrize(
+    "annotation,expected",
+    [
+        (int, "INT"),
+        (float, "DOUBLE"),
+        (bool, "BOOLEAN"),
+        (str, "TEXT"),
+        (datetime, "DATETIME"),
+        (date, "DATE"),
+        (UUID, "CHAR(36)"),
+        (list, "JSON"),
+        (list[int], "JSON"),
+        (int | None, "INT"),
+        (bool | None, "BOOLEAN"),
+    ],
+)
+def test_mysql_type_map(annotation, expected):
+    assert MySQLDialect.python_to_sql_type(annotation) == expected
+
+
+def test_mysql_type_map_rejects_unknown():
+    with pytest.raises(TypeError):
+        MySQLDialect.python_to_sql_type(object)
+
+
+def test_mysql_autoincrement_pk():
+    assert MySQLDialect().auto_increment_pk("id") == "`id` INT AUTO_INCREMENT PRIMARY KEY"
+
+
+def test_mysql_does_not_support_returning():
+    d = MySQLDialect()
+    assert d.supports_returning is False
+    assert d.render_returning("id") == ""
+
+
+def test_mysql_insert_has_no_returning():
+    compiler = Compiler(MySQLDialect())
+    query = InsertQuery(
+        table="users",
+        columns=("username", "email"),
+        values=("alice", "alice@example.com"),
+        returning="id",
+    )
+    sql, params = compiler.compile_insert(query)
+    assert sql == "INSERT INTO `users` (`username`, `email`) VALUES (%s, %s)"
+    assert params == ["alice", "alice@example.com"]


### PR DESCRIPTION
Completes **Epic A — Dialect & SQL-builder foundation**. With this, RiverORM emits correct SQL for **both Postgres and MySQL** from one backend-agnostic codebase, and the test suite proves it on both.

## What
- **`MySQLDialect`** (#82): backtick quoting, `%s` placeholders, MySQL type map (`bool→BOOLEAN`, `int→INT`, `float→DOUBLE`, `str→TEXT`, `datetime→DATETIME`, `UUID→CHAR(36)`, `list→JSON`), `AUTO_INCREMENT` PK, `supports_returning = False`.
- **MySQL driver completed**: `DictCursor` rows, `%s` params, `autocommit`, and a new `execute_insert()` that returns `cursor.lastrowid`. `save()` backfills the PK via `RETURNING` (Postgres) or `lastrowid` (MySQL), branching on `dialect.supports_returning`.
- **`dialect`/`compiler` on the driver layer**; `python_to_sql_type`/auto-increment logic moved out of the drivers into the dialect.
- **Test matrix enabled** (#83): `conftest` runs every DB-backed test on `[postgres, mysql]`.
- **Drivers de-sniffed** (#84): removed query-prefix validation and `;`-appending; drivers only execute + debug-log.

## Why
Fixes the long-standing bug where Postgres-only `$1` placeholders silently broke MySQL. The dialect now encapsulates all backend differences, so SQLite (Epic G) is a small add later.

## Tests
**162 passing** across both backends (every ORM test parametrized `[postgres, mysql]`, plus 84 DB-free compiler/dialect unit cases). ruff + mypy clean. Closes #82, #83, #84.