### PR TITLE
chore: from __future__ import annotations + lazy forward-ref resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Read more details about our [mission](docs/MISSION.md).
 A minimal but complete example showing async usage, model definition, and multi-database support:
 
 ```python
+from __future__ import annotations
+
 from riverorm import Field, Model
 from riverorm.db import DatabaseRegistry, MySQLDatabase, PostgresDatabase
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -119,11 +119,15 @@ Relationships are declared with a **foreign-key column** plus an annotated
 a field typed as a `list[...]` of the related model.
 
 ```python
+from __future__ import annotations
+
+from riverorm import Field, Model
+
 class User(Model):
     id: int | None = Field(default=None)
     username: str
     # Reverse relation — populated by load_related("orders")
-    orders: list["Order"] = Field(default_factory=list)
+    orders: list[Order] = Field(default_factory=list)
 
 class Order(Model):
     id: int | None = Field(default=None)
@@ -131,8 +135,8 @@ class Order(Model):
     user_id: int | None = Field(default=None)     # foreign key column
     product_id: int | None = Field(default=None)  # foreign key column
     # Forward relations — populated by select_related(...) / load_related(...)
-    user: "User | None" = Field(default=None)
-    product: "Product | None" = Field(default=None)
+    user: User | None = Field(default=None)
+    product: Product | None = Field(default=None)
 ```
 
 Relation fields (`user`, `product`, `orders`) are *virtual*: they are never

--- a/docs/adr/0001-future-annotations-lazy-forward-ref-resolution.md
+++ b/docs/adr/0001-future-annotations-lazy-forward-ref-resolution.md
@@ -1,0 +1,77 @@
+# 0001 — `from __future__ import annotations` with lazy forward-reference resolution
+
+**Status:** accepted  
+**Date:** 2026-06-20
+
+## Context
+
+RiverORM models use Pydantic v2 `BaseModel` and rely on type annotations for
+two purposes: Pydantic validation and ORM type introspection (identifying
+relation fields, determining column types, etc.).
+
+When models reference each other in a circular or forward manner — e.g. `User`
+has `orders: list[Order]` but `Order` is defined after `User` in the same
+module — Python raises `NameError` unless the reference is quoted as a string
+(`"Order"`). This manual quoting is verbose and inconsistent.
+
+PEP 563 (`from __future__ import annotations`) makes *all* annotations lazy
+strings automatically, removing the need for explicit quotes. However, Pydantic
+marks a model as `__pydantic_complete__ = False` when it cannot resolve its
+annotations at class-creation time. The canonical Pydantic fix is to call
+`model_rebuild()` explicitly after all classes are defined — but this is user-
+visible boilerplate that defeats the ergonomic goal.
+
+We evaluated several approaches to automate the rebuild:
+
+| Approach | Why it fails / is suboptimal |
+| --- | --- |
+| `__init_subclass__` eager rebuild | Hook fires *before* the class is bound in the module namespace, so the new class is not yet in `sys.modules[module].__dict__`. Rebuild with the class injected via `_types_namespace` triggers a different Pydantic error ("Class X is not defined") after partial resolution. |
+| Global model registry + eager rebuild on each new class | Same root problem as `__init_subclass__`. Works only if no model references a class defined after it in the file, which is the common case we're trying to fix. |
+| Require explicit `model_rebuild()` in user code | Leaks an internal Pydantic concept, breaks the "just define your classes" ergonomic promise, and is error-prone. |
+| Lazy resolution on first ORM use | By the time any query or introspection method is called, the module is fully loaded and all classes are in `sys.modules`. Calling `model.model_rebuild(_types_namespace=vars(sys.modules[model.__module__]))` always succeeds. |
+
+The lazy approach mirrors how SQLAlchemy 2.x resolves Annotated Mapped types
+(deferred mapper configuration at first session use) and how Peewee resolves
+`ForeignKeyField("ModelName")` (lookup at query generation time).
+
+## Decision
+
+Add `from __future__ import annotations` to every source and test file.
+Replace all explicit string-quoted forward references (`"Order"`, `"User | None"`)
+with bare unquoted syntax (`Order`, `User | None`).
+
+Introduce a private `_ensure_model_complete(model)` helper in `riverorm/models.py`
+that checks `model.__pydantic_complete__` and, if `False`, calls
+`model.model_rebuild(_types_namespace=vars(sys.modules[model.__module__]))`.
+Call this helper at the two ORM entry points that do type introspection:
+
+- `Model.model_virtual_fields()` — resolves the current model before inspecting
+  which fields are relation fields.
+- `Model._prefetch_related()` — resolves before walking `model_fields` to
+  identify the related model class for each relation spec.
+
+All other introspection paths (`model_real_fields`, `_build_rel_map`,
+`create_table`, `save`, query execution) flow through one of these two methods,
+so a single guard at each entry point is sufficient.
+
+## Consequences
+
+**Positive**
+- Users never call `model_rebuild()` or quote forward references. Models just work
+  regardless of definition order in the file.
+- All annotation syntax is modern and uniform throughout the codebase.
+- Resolution is transparent: happens once per model, cached by Pydantic via
+  `__pydantic_complete__`.
+- Aligns with the pattern used by major async ORMs (SQLAlchemy, Peewee).
+
+**Negative / obligations**
+- Any new ORM entry point that directly accesses `model_fields` or annotation
+  data without going through `model_virtual_fields` or `_prefetch_related` must
+  also call `_ensure_model_complete(cls)` first, or risk receiving a `ForwardRef`
+  instead of a resolved type. This requirement must be documented when adding
+  new introspection paths.
+- `_ensure_model_complete` calls `model_rebuild(raise_errors=True)`, so any
+  genuinely unresolvable annotation (e.g. a typo in the class name) surfaces as
+  a `PydanticUndefinedAnnotation` on the first ORM use rather than at class
+  definition time. The error message is clear, but the timing differs from a
+  plain Pydantic model.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,18 @@
+# NNNN — Title
+
+**Status:** accepted | superseded by #NNNN | deprecated  
+**Date:** YYYY-MM-DD
+
+## Context
+
+What is the situation or problem that prompted this decision? Include
+constraints, forces at play, and alternatives that were considered.
+
+## Decision
+
+What did we decide, and what is the one-sentence rationale?
+
+## Consequences
+
+What becomes easier or harder because of this decision? List both positive and
+negative outcomes, including any obligations it places on future contributors.

--- a/riverorm/__init__.py
+++ b/riverorm/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .fields import Field as Field
 from .fields import FieldMeta as FieldMeta
 from .models import Model as Model

--- a/riverorm/config.py
+++ b/riverorm/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass
 

--- a/riverorm/db/__init__.py
+++ b/riverorm/db/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .base import BaseDatabase as BaseDatabase
 from .mysql import MySQLDatabase as MySQLDatabase
 from .postgres import PostgresDatabase as PostgresDatabase

--- a/riverorm/db/base.py
+++ b/riverorm/db/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Any, Sequence
 

--- a/riverorm/db/mysql.py
+++ b/riverorm/db/mysql.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import aiomysql

--- a/riverorm/db/postgres.py
+++ b/riverorm/db/postgres.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import asyncpg

--- a/riverorm/db/registry.py
+++ b/riverorm/db/registry.py
@@ -1,5 +1,7 @@
 """Database connection registry for managing multiple database instances."""
 
+from __future__ import annotations
+
 from riverorm.db import BaseDatabase
 
 

--- a/riverorm/models.py
+++ b/riverorm/models.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import re
+import sys
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Any, ClassVar, TypeVar, get_args, get_origin
@@ -41,7 +44,7 @@ def _camel_to_snake(name: str) -> str:
     return name.lower()
 
 
-def _related_model_from_annotation(annotation: Any) -> tuple[type["Model"] | None, bool]:
+def _related_model_from_annotation(annotation: Any) -> tuple[type[Model] | None, bool]:
     """
     Inspect a field annotation and return ``(related_model, is_collection)``.
 
@@ -56,7 +59,7 @@ def _related_model_from_annotation(annotation: Any) -> tuple[type["Model"] | Non
     return (_single_model(annotation), False)
 
 
-def _single_model(annotation: Any) -> type["Model"] | None:
+def _single_model(annotation: Any) -> type[Model] | None:
     """Return the ``Model`` subclass referenced by an annotation, unwrapping ``| None``."""
     if isinstance(annotation, type) and issubclass(annotation, Model):
         return annotation
@@ -64,6 +67,24 @@ def _single_model(annotation: Any) -> type["Model"] | None:
         if isinstance(arg, type) and issubclass(arg, Model):
             return arg
     return None
+
+
+def _ensure_model_complete(model: type[Model]) -> None:
+    """Resolve any deferred Pydantic forward references on *model*.
+
+    With ``from __future__ import annotations`` every annotation is stored as a
+    string.  Pydantic defers the evaluation if a referenced class isn't yet
+    defined when the model class body runs (e.g. ``User`` references ``Order``
+    before ``Order`` is declared).  By the time *any* ORM method is called the
+    defining module is already fully loaded, so ``sys.modules`` contains all the
+    classes and Pydantic can resolve everything without manual ``model_rebuild()``
+    calls from user code.
+    """
+    if getattr(model, "__pydantic_complete__", True):
+        return
+    module = sys.modules.get(model.__module__)
+    ns = vars(module) if module is not None else None
+    model.model_rebuild(raise_errors=True, _types_namespace=ns)
 
 
 class Model(BaseModel):
@@ -186,6 +207,7 @@ class Model(BaseModel):
         These are populated by ``select_related`` / ``load_related`` and are never stored
         as columns.
         """
+        _ensure_model_complete(cls)
         return {
             name: field
             for name, field in cls.model_fields.items()
@@ -324,7 +346,7 @@ class Model(BaseModel):
         return await cls.objects.filter(**kwargs).all()
 
     @classmethod
-    def _build_rel_map(cls, related_fields: Sequence[str]) -> dict[str, tuple[str, type["Model"]]]:
+    def _build_rel_map(cls, related_fields: Sequence[str]) -> dict[str, tuple[str, type[Model]]]:
         """Map each ``select_related`` field to its ``(fk_field, related_model)``.
 
         Only direct forward foreign keys are supported (e.g. ``user`` via
@@ -344,7 +366,7 @@ class Model(BaseModel):
             if rel in cls.model_fields:
                 related_model = _related_model_from_annotation(cls.model_fields[rel].annotation)[0]
             if related_model is None:
-                related_model = getattr(mod, rel.capitalize(), None)
+                related_model = getattr(mod, rel.capitalize(), None)  # type: ignore[assignment]
             if related_model is None:
                 raise ValueError(f"Related model class for '{rel}' not found in module {mod}")
             rel_map[rel] = (fk_field, related_model)
@@ -352,7 +374,7 @@ class Model(BaseModel):
 
     @classmethod
     def _select_related_columns_and_joins(
-        cls, rel_map: dict[str, tuple[str, type["Model"]]]
+        cls, rel_map: dict[str, tuple[str, type[Model]]]
     ) -> tuple[tuple[Column, ...], tuple[Join, ...]]:
         """Build the projected columns and LEFT JOINs for a ``select_related`` query."""
         base_alias = cls.table_name()
@@ -377,7 +399,7 @@ class Model(BaseModel):
 
     @classmethod
     def _hydrate_select_related(
-        cls: type[T], row: Any, rel_map: dict[str, tuple[str, type["Model"]]]
+        cls: type[T], row: Any, rel_map: dict[str, tuple[str, type[Model]]]
     ) -> T:
         """Build an instance from a joined row, attaching the related objects."""
         base_data: dict[str, Any] = {}
@@ -425,10 +447,11 @@ class Model(BaseModel):
         return cls.objects.load_related(*related_fields)
 
     @classmethod
-    async def _prefetch_related(cls, objects: Sequence["Model"], specs: list[str]) -> None:
+    async def _prefetch_related(cls, objects: Sequence[Model], specs: list[str]) -> None:
         """Populate the relations named in ``specs`` on ``objects`` with batched queries."""
         if not objects or not specs:
             return
+        _ensure_model_complete(cls)
 
         # Group ``"product__user"`` style specs by their root relation.
         groups: dict[str, list[str]] = {}
@@ -455,8 +478,8 @@ class Model(BaseModel):
 
     @classmethod
     async def _prefetch_forward(
-        cls, objects: Sequence["Model"], root: str, related_model: type["Model"]
-    ) -> list["Model"]:
+        cls, objects: Sequence[Model], root: str, related_model: type[Model]
+    ) -> list[Model]:
         """Load a forward FK relation (``cls`` has ``<root>_id``) and attach single objects."""
         fk = f"{root}_id"
         ids = {getattr(obj, fk) for obj in objects if getattr(obj, fk, None) is not None}
@@ -468,8 +491,8 @@ class Model(BaseModel):
 
     @classmethod
     async def _prefetch_reverse(
-        cls, objects: Sequence["Model"], root: str, related_model: type["Model"]
-    ) -> list["Model"]:
+        cls, objects: Sequence[Model], root: str, related_model: type[Model]
+    ) -> list[Model]:
         """Load a reverse relation (related rows point back via ``<cls>_id``) as lists."""
         back_fk = f"{_camel_to_snake(cls.__name__)}_id"
         pk = cls.primary_key()

--- a/riverorm/sql/__init__.py
+++ b/riverorm/sql/__init__.py
@@ -8,6 +8,8 @@ string for a particular database (:class:`~riverorm.sql.dialect.Dialect` plus
 It is intentionally pure: no database connections, no I/O.
 """
 
+from __future__ import annotations
+
 from .compiler import Compiler as Compiler
 from .dialect import Dialect as Dialect
 from .dialect import MySQLDialect as MySQLDialect

--- a/riverorm/utils.py
+++ b/riverorm/utils.py
@@ -1,5 +1,7 @@
 """Utilities for RiverORM."""
 
+from __future__ import annotations
+
 import types
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 import pytest_asyncio
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from riverorm import Field, Model
 
 
@@ -11,8 +13,8 @@ class User(Model):
     email: str | None = Field(default=None, description="Email address of the user")
     is_active: bool = Field(True, description="Is the user active?")
     # Reverse relations (populated by load_related), never stored as columns.
-    products: list["Product"] = Field(default_factory=list, description="Products owned by user")
-    orders: list["Order"] = Field(default_factory=list, description="Orders placed by the user")
+    products: list[Product] = Field(default_factory=list, description="Products owned by user")
+    orders: list[Order] = Field(default_factory=list, description="Orders placed by the user")
 
 
 class Product(Model):
@@ -27,8 +29,8 @@ class Product(Model):
     in_stock: bool = Field(True, description="Is the product in stock?")
     user_id: int | None = Field(default=None, description="Owner user id of the product")
     # Forward and reverse relations (populated by select_related / load_related).
-    user: "User | None" = Field(default=None, description="Owner of the product")
-    orders: list["Order"] = Field(default_factory=list, description="Orders for this product")
+    user: User | None = Field(default=None, description="Owner of the product")
+    orders: list[Order] = Field(default_factory=list, description="Orders for this product")
 
 
 class Order(Model):
@@ -43,5 +45,5 @@ class Order(Model):
     user_id: int | None = Field(default=None, description="User who placed the order")
     product_id: int | None = Field(default=None, description="Product ordered")
     # Forward relations (populated by select_related / load_related).
-    user: "User | None" = Field(default=None, description="User who placed the order")
-    product: "Product | None" = Field(default=None, description="Product ordered")
+    user: User | None = Field(default=None, description="User who placed the order")
+    product: Product | None = Field(default=None, description="Product ordered")

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from tests.models import Order, Product, User
 
 

--- a/tests/test_field_pk.py
+++ b/tests/test_field_pk.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from tests.models import User

--- a/tests/test_load_related.py
+++ b/tests/test_load_related.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from tests.models import Order, Product, User

--- a/tests/test_orm_features.py
+++ b/tests/test_orm_features.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from tests.models import Product, User

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from riverorm.queryset import Manager, QuerySet

--- a/tests/test_select_related.py
+++ b/tests/test_select_related.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from tests.models import Product, User

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -4,6 +4,8 @@ These tests are deliberately database-free: they exercise only the pure
 dialect + compiler machinery and assert exact ``(sql, params)`` output.
 """
 
+from __future__ import annotations
+
 from datetime import date, datetime
 from uuid import UUID
 

--- a/tests/test_table_name.py
+++ b/tests/test_table_name.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import ClassVar
 
 import pytest


### PR DESCRIPTION
## Summary

- Adds `from __future__ import annotations` to every source and test file so forward references in model annotations no longer need explicit string quoting (`"Order"` → `Order`, `"User | None"` → `User | None`).
- Introduces `_ensure_model_complete(model)` in `riverorm/models.py` — a private guard that calls `model.model_rebuild()` (with the model's own module namespace) on the first ORM use if Pydantic deferred type resolution at class-creation time. Called at the two introspection entry points: `model_virtual_fields()` and `_prefetch_related()`.
- Adds `docs/adr/0001-future-annotations-lazy-forward-ref-resolution.md` documenting the decision, the three alternative approaches that were evaluated and discarded, and the obligations this places on future contributors.
- Adds `docs/adr/template.md` for future ADRs.

## Why lazy resolution (not eager / __init_subclass__)

`__init_subclass__` fires *before* the class is bound into the module namespace, so the newly-defined class cannot be found in `sys.modules` during the hook. By the time any ORM method runs, the module is fully loaded — the same pattern SQLAlchemy 2.x uses for Annotated Mapped type resolution.

## Test plan

- [x] `uv run ruff check` — passes
- [x] `uv run mypy .` — passes (no errors, only pre-existing notes)
- [x] `uv run pytest -v` against the throwaway dual-backend stack (postgres:18 + mysql:9)