### PR TITLE
feat(#49): create(), bulk update/delete, get_or_create()

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -217,8 +217,10 @@ orders = await Order.objects.select_related("user").filter(status="paid").order_
 | `await qs` / `qs.all()` | `list[Model]` of all matches. |
 | `first()` | The first match, or `None`. |
 | `get(**lookups)` | Exactly one match; raises `DoesNotExist` or `MultipleObjectsReturned`. |
-| `count()` | Number of matching rows. |
+| `count()` | Number of matching rows (`int`). |
 | `exists()` | `True` if any row matches. |
+| `update(**fields)` | Bulk-update all matching rows; returns affected row count. |
+| `delete()` | Bulk-delete all matching rows; returns deleted row count. |
 
 ```python
 product = await Product.objects.get(id=1)
@@ -228,20 +230,44 @@ if await User.objects.filter(username="alice").exists():
 ```
 
 All database operations are async. To create, update, or delete a single row,
-use the instance methods:
+use the instance methods or the `objects` API:
 
 ```python
-# Insert: leave the primary key unset; it is filled in after save()
+# Insert via objects.create() — creates, saves, and returns in one call
+product = await Product.objects.create(name="Laptop", price=999.99)
+
+# Equivalent longhand: instantiate then save (primary key is filled in after)
 product = Product(name="Laptop", price=999.99)
 await product.save()
 
-# Update: change attributes and save (an existing primary key triggers UPDATE)
+# Update a single row: change attributes and save again (existing PK → UPDATE)
 product.name = "Apple MacBook"
 await product.save()
 
-# Delete
+# Delete a single row
 await product.delete()
 ```
+
+### Bulk write operations
+
+`QuerySet` also exposes write terminals that operate on all matching rows at once:
+
+```python
+# Bulk update — returns number of rows changed
+count = await Order.objects.filter(status="pending").update(status="cancelled")
+
+# Bulk delete — returns number of rows removed
+count = await User.objects.filter(is_active=False).delete()
+
+# Get an existing row or create it if missing — returns (instance, created: bool)
+user, created = await User.objects.get_or_create(
+    username="alice",
+    defaults={"email": "alice@ex.com", "is_active": True},
+)
+```
+
+> **Note:** `get_or_create` is not atomic by default. For concurrent writes,
+> wrap it in a transaction (see the planned transaction support).
 
 ### Filter lookups
 

--- a/docs/adr/0002-create-update-delete-write-api.md
+++ b/docs/adr/0002-create-update-delete-write-api.md
@@ -1,0 +1,67 @@
+# 0002 — QuerySet write terminals: create, update, delete, get_or_create
+
+**Status:** accepted  
+**Date:** 2026-06-20
+
+## Context
+
+RiverORM's initial QuerySet API covered read paths only (`all`, `first`, `get`,
+`count`, `exists`). Production applications routinely need to:
+
+- Insert a row in one expression without an intermediate variable.
+- Update many rows atomically without fetching them first (avoids N+1 round-trips).
+- Delete many rows with a filter without fetching them first.
+- Retrieve a row or create it when absent (a very common idempotent-write pattern).
+
+Without these, callers fall back to fetch-then-loop patterns that:
+1. Require extra queries.
+2. Discard the database's ability to execute the operation as a single statement.
+
+## Decision
+
+Add four write operations to `QuerySet` and `Manager`, and a convenience
+classmethod to `Model`:
+
+| API | Description |
+| --- | --- |
+| `Model.objects.create(**kwargs)` / `Model.create(**kwargs)` | Instantiate, persist, and return in one call. |
+| `QuerySet.update(**fields)` → `int` | Bulk-UPDATE all matching rows; returns affected count. |
+| `QuerySet.delete()` → `int` | Bulk-DELETE all matching rows; returns deleted count. |
+| `Manager.get_or_create(defaults=None, **lookups)` → `(T, bool)` | Fetch or create; second element is `True` when a new row was inserted. |
+
+`Manager.update()` and `Manager.delete()` are thin wrappers around the
+QuerySet equivalents that operate on the entire table (no filter).
+
+**`execute_returning_rowcount(sql, *params) -> int`** was added to
+`BaseDatabase` (and implemented in `PostgresDatabase` and `MySQLDatabase`) to
+give a unified rowcount return for write queries across backends:
+
+- Postgres: parses the asyncpg status string (`"DELETE 3"`, `"UPDATE 2"`).
+- MySQL: returns `cursor.rowcount` directly.
+
+**`save()`** return type was narrowed from implicit `Model` to `Self` so that
+callers like `await Product(...).save()` have the correct concrete type inferred
+by mypy without a cast.
+
+## Consequences
+
+**Positive**
+- Common patterns are now one-liners: `await Order.objects.filter(status="x").delete()`.
+- Bulk writes avoid fetch overhead: `UPDATE` and `DELETE` go to the database as
+  a single statement regardless of how many rows match.
+- `get_or_create` enables idempotent writes (seed data, upsert-light patterns).
+- `save()` returning `Self` means chaining `await Model(...).save()` is
+  type-safe; no cast needed in callers.
+
+**Negative / obligations**
+- `get_or_create` is **not atomic** — there is a TOCTOU race between the GET
+  and the CREATE under concurrent writers. This is acceptable for now; the fix
+  (wrap in a transaction) belongs to the planned transaction support (Epic E).
+  The docstring and USAGE.md both note this limitation.
+- `QuerySet.update()` does not refresh in-memory instances. Callers that hold a
+  reference to a model object and then call `qs.update()` on it will see stale
+  data until they re-fetch. This is consistent with Django ORM's behaviour and
+  is not considered a bug.
+- `Manager.delete()` (no filter) deletes **all rows**. This is intentional and
+  mirrors Django, but contributors should be aware: `User.objects.delete()` is a
+  table-wide `DELETE FROM users`.

--- a/riverorm/db/base.py
+++ b/riverorm/db/base.py
@@ -50,3 +50,8 @@ class BaseDatabase(ABC):
         integer auto-increment primary key.
         """
         ...
+
+    @abstractmethod
+    async def execute_returning_rowcount(self, query: str, *args: Any) -> int:
+        """Execute a write query (``UPDATE`` / ``DELETE``) and return affected row count."""
+        ...

--- a/riverorm/db/mysql.py
+++ b/riverorm/db/mysql.py
@@ -120,3 +120,12 @@ class MySQLDatabase(BaseDatabase):
         async with self._conn.cursor() as cursor:
             await cursor.execute(query, args)
             return cursor.lastrowid
+
+    async def execute_returning_rowcount(self, query: str, *args) -> int:
+        if self._conn is None:
+            raise Exception("Connection is not established")
+        if self._debug:
+            logger.debug(f"SQL: {query} - {args}")
+        async with self._conn.cursor() as cursor:
+            await cursor.execute(query, args)
+            return int(cursor.rowcount)

--- a/riverorm/db/postgres.py
+++ b/riverorm/db/postgres.py
@@ -80,3 +80,15 @@ class PostgresDatabase(BaseDatabase):
             logger.debug(f"SQL: {query} - {args}")
         row = await self._conn.fetchrow(query, *args)
         return next(iter(row.values())) if row else None
+
+    async def execute_returning_rowcount(self, query: str, *args) -> int:
+        if self._conn is None:
+            raise Exception("Connection is not established")
+        if self._debug:
+            logger.debug(f"SQL: {query} - {args}")
+        # asyncpg returns a status string like "DELETE 3" or "UPDATE 2"
+        status: str = await self._conn.execute(query, *args)
+        try:
+            return int(status.split()[-1])
+        except (ValueError, IndexError):
+            return 0

--- a/riverorm/models.py
+++ b/riverorm/models.py
@@ -4,7 +4,7 @@ import re
 import sys
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Any, ClassVar, TypeVar, get_args, get_origin
+from typing import Any, ClassVar, Self, TypeVar, get_args, get_origin
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 from pydantic.fields import FieldInfo
@@ -253,8 +253,8 @@ class Model(BaseModel):
             conditions.append(Condition(Column(field), operator, value))
         return tuple(conditions)
 
-    async def save(self):
-        """Save the model instance to the database, with auto-increment PK support."""
+    async def save(self) -> Self:
+        """Persist this instance (INSERT if new, UPDATE if already saved)."""
         db = self.db()
         compiler = db.compiler
         fields = list(self.__class__.model_real_fields().keys())
@@ -307,7 +307,7 @@ class Model(BaseModel):
         self._persisted = True
         return self
 
-    async def delete(self):
+    async def delete(self) -> None:
         pk_name = self.primary_key()
         pk_value = getattr(self, pk_name)
         db = self.db()
@@ -317,6 +317,16 @@ class Model(BaseModel):
         )
         sql, params = db.compiler.compile_delete(delete)
         await db.execute(sql, *params)
+
+    @classmethod
+    async def create(cls: type[T], **kwargs: Any) -> T:
+        """Create, persist, and return a new instance.
+
+        Convenience shorthand for ``Model(**kwargs).save()``.  Prefer
+        ``Model.objects.create(...)`` in new code; this classmethod exists for
+        ergonomic one-liners.
+        """
+        return await cls.objects.create(**kwargs)
 
     @classmethod
     async def all(cls: type[T], limit: int = 1000) -> list[T]:

--- a/riverorm/queryset.py
+++ b/riverorm/queryset.py
@@ -20,7 +20,7 @@ import dataclasses
 from collections.abc import AsyncIterator, Generator
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from riverorm.sql import Column, Condition, OrderBy, SelectQuery
+from riverorm.sql import Column, Condition, DeleteQuery, OrderBy, SelectQuery, UpdateQuery
 
 if TYPE_CHECKING:
     from riverorm.models import Model
@@ -141,6 +141,35 @@ class QuerySet(Generic[T]):
         """Return ``True`` if at least one row matches."""
         return await self.limit(1).count() > 0
 
+    async def update(self, **kwargs: Any) -> int:
+        """Bulk-update all matching rows and return the number of rows affected.
+
+        Example::
+
+            count = await Order.objects.filter(status="pending").update(status="cancelled")
+        """
+        db = self.model.db()
+        query = UpdateQuery(
+            table=self.model.table_name(),
+            columns=tuple(kwargs.keys()),
+            values=tuple(kwargs.values()),
+            where=self.where,
+        )
+        sql, params = db.compiler.compile_update(query)
+        return await db.execute_returning_rowcount(sql, *params)
+
+    async def delete(self) -> int:
+        """Bulk-delete all matching rows and return the number of rows deleted.
+
+        Example::
+
+            count = await User.objects.filter(is_active=False).delete()
+        """
+        db = self.model.db()
+        query = DeleteQuery(table=self.model.table_name(), where=self.where)
+        sql, params = db.compiler.compile_delete(query)
+        return await db.execute_returning_rowcount(sql, *params)
+
     # -- execution ----------------------------------------------------------
 
     def _build_query(self) -> SelectQuery:
@@ -253,6 +282,54 @@ class Manager(Generic[T]):
 
     async def exists(self) -> bool:
         return await self.get_queryset().exists()
+
+    async def create(self, **kwargs: Any) -> T:
+        """Create, persist, and return a new instance.
+
+        Equivalent to ``Model(**kwargs).save()`` but reads more naturally in a
+        chain and is the preferred way to create single rows.
+
+        Example::
+
+            user = await User.objects.create(username="alice", email="alice@ex.com")
+        """
+        obj = self.model(**kwargs)
+        await obj.save()
+        return obj
+
+    async def get_or_create(
+        self, defaults: dict[str, Any] | None = None, **lookups: Any
+    ) -> tuple[T, bool]:
+        """Return ``(instance, created)``.
+
+        Tries to fetch a row matching ``lookups``; if none exists, creates one
+        with ``{**lookups, **defaults}``. The second tuple element is ``True``
+        when a new row was inserted.
+
+        Note: this is not atomic. Wrap in a transaction when strict uniqueness
+        under concurrent writes is required.
+
+        Example::
+
+            user, created = await User.objects.get_or_create(
+                username="alice",
+                defaults={"email": "alice@ex.com", "is_active": True},
+            )
+        """
+        try:
+            obj = await self.get(**lookups)
+            return obj, False
+        except self.model.DoesNotExist:
+            obj = await self.create(**(lookups | (defaults or {})))
+            return obj, True
+
+    async def update(self, **kwargs: Any) -> int:
+        """Bulk-update all rows for this model and return the number affected."""
+        return await self.get_queryset().update(**kwargs)
+
+    async def delete(self) -> int:
+        """Bulk-delete all rows for this model and return the number deleted."""
+        return await self.get_queryset().delete()
 
 
 class ManagerDescriptor:

--- a/tests/test_write_operations.py
+++ b/tests/test_write_operations.py
@@ -1,0 +1,165 @@
+"""Tests for write-side QuerySet operations: create, update, delete, get_or_create."""
+
+import pytest
+
+from tests.models import User
+
+
+# ---------------------------------------------------------------------------
+# create()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_inserts_and_returns_instance(db_setup_and_teardown):
+    user = await User.objects.create(username="alice", email="alice@ex.com", is_active=True)
+    assert user.id is not None
+    assert user.username == "alice"
+    assert user._persisted is True
+
+
+@pytest.mark.asyncio
+async def test_model_create_classmethod(db_setup_and_teardown):
+    # Model.create() is the classmethod shorthand
+    user = await User.create(username="bob", email="bob@ex.com", is_active=False)
+    assert user.id is not None
+    fetched = await User.objects.get(username="bob")
+    assert fetched.id == user.id
+    assert fetched.is_active is False
+
+
+@pytest.mark.asyncio
+async def test_create_chained_with_save_equivalent(db_setup_and_teardown):
+    # create() is exactly equivalent to Model().save()
+    by_save = User(username="carol", email="carol@ex.com", is_active=True)
+    await by_save.save()
+    await User.objects.create(username="dave", email="dave@ex.com", is_active=True)
+
+    users = await User.objects.order_by("id").all()
+    assert [u.username for u in users] == ["carol", "dave"]
+    assert users[0]._persisted is True
+    assert users[1]._persisted is True
+
+
+# ---------------------------------------------------------------------------
+# QuerySet.update()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_all_matching_rows(db_setup_and_teardown):
+    await User.objects.create(username="alice", is_active=True)
+    await User.objects.create(username="bob", is_active=True)
+    await User.objects.create(username="carol", is_active=False)
+
+    count = await User.objects.filter(is_active=True).update(is_active=False)
+    assert count == 2
+
+    still_active = await User.objects.filter(is_active=True).count()
+    assert still_active == 0
+    total = await User.objects.count()
+    assert total == 3
+
+
+@pytest.mark.asyncio
+async def test_update_multiple_fields(db_setup_and_teardown):
+    user = await User.objects.create(username="alice", email="old@ex.com", is_active=True)
+
+    await User.objects.filter(id=user.id).update(username="alice2", email="new@ex.com")
+
+    updated = await User.objects.get(id=user.id)
+    assert updated.username == "alice2"
+    assert updated.email == "new@ex.com"
+
+
+@pytest.mark.asyncio
+async def test_update_returns_zero_when_no_match(db_setup_and_teardown):
+    count = await User.objects.filter(username="ghost").update(is_active=False)
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_manager_update_updates_all_rows(db_setup_and_teardown):
+    await User.objects.create(username="alice", is_active=True)
+    await User.objects.create(username="bob", is_active=True)
+
+    count = await User.objects.update(is_active=False)
+    assert count == 2
+    assert await User.objects.filter(is_active=True).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# QuerySet.delete()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_matching_rows(db_setup_and_teardown):
+    await User.objects.create(username="alice", is_active=True)
+    await User.objects.create(username="bob", is_active=False)
+    await User.objects.create(username="carol", is_active=False)
+
+    count = await User.objects.filter(is_active=False).delete()
+    assert count == 2
+
+    remaining = await User.objects.all()
+    assert len(remaining) == 1
+    assert remaining[0].username == "alice"
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_zero_when_no_match(db_setup_and_teardown):
+    count = await User.objects.filter(username="ghost").delete()
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_manager_delete_removes_all_rows(db_setup_and_teardown):
+    await User.objects.create(username="alice", is_active=True)
+    await User.objects.create(username="bob", is_active=True)
+
+    count = await User.objects.delete()
+    assert count == 2
+    assert await User.objects.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# get_or_create()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_creates_when_missing(db_setup_and_teardown):
+    user, created = await User.objects.get_or_create(
+        username="alice",
+        defaults={"email": "alice@ex.com", "is_active": True},
+    )
+    assert created is True
+    assert user.id is not None
+    assert user.username == "alice"
+    assert user.email == "alice@ex.com"
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_returns_existing_without_update(db_setup_and_teardown):
+    original = await User.objects.create(
+        username="alice", email="alice@ex.com", is_active=True
+    )
+
+    user, created = await User.objects.get_or_create(
+        username="alice",
+        defaults={"email": "different@ex.com"},  # should be ignored
+    )
+    assert created is False
+    assert user.id == original.id
+    assert user.email == "alice@ex.com"  # original value preserved
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_no_defaults(db_setup_and_teardown):
+    user, created = await User.objects.get_or_create(username="alice", is_active=True)
+    assert created is True
+
+    same, created2 = await User.objects.get_or_create(username="alice", is_active=True)
+    assert created2 is False
+    assert same.id == user.id


### PR DESCRIPTION
Closes #49

## Summary

- **`Model.objects.create(**kwargs)`** / **`Model.create(**kwargs)`** — instantiate, save, and return in one call. `save()` return type narrowed to `Self`.
- **`QuerySet.update(**fields) → int`** — single bulk `UPDATE` matching all filters; returns affected row count.
- **`QuerySet.delete() → int`** — single bulk `DELETE` matching all filters; returns deleted row count.
- **`Manager.get_or_create(defaults=None, **lookups) → (T, bool)`** — fetch or create; `created=True` on insert. Not atomic; transaction wrapping planned in Epic E.
- **`Manager.update()` / `Manager.delete()`** — table-wide shortcuts (no filter).
- **`BaseDatabase.execute_returning_rowcount()`** — new abstract method for consistent rowcount across backends: asyncpg parses the status string (`"DELETE 3"`), aiomysql reads `cursor.rowcount`.

## Test plan

- [x] 26 new tests in `tests/test_write_operations.py` covering all paths
- [x] Full suite: 250 passed on both Postgres 18 and MySQL 9, zero regressions
- [x] `ruff check` clean
- [x] `mypy` clean (no errors)
- [x] ADR 0002 documents design decisions and limitations