### PR TITLE
Epic C (2/2): Annotated field syntax, nullable DDL, to_dict/to_json (#28, #30)

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -63,14 +63,43 @@ If no connections are registered, or a model's `db_alias` is not found, any DB o
 
 Models in RiverORM inherit from `Model` and use type annotations with `Field` for schema definition. Fields are real Pydantic fields, so you get validation and metadata for free.
 
+Two equivalent syntaxes are supported — choose whichever fits your style:
+
 ```python
 from riverorm import Field, Model
 
+# Classic assignment style
 class Product(Model):
     id: int | None = Field(default=None)  # `id` is the primary key by default
-    name: str
+    name: str = Field(max_length=200)
     price: float
     in_stock: bool = Field(True)
+
+# Annotated style (PEP 593) — keeps type and metadata visually separate
+from typing import Annotated
+
+class Product(Model):
+    id: int | None = Field(default=None)
+    name: Annotated[str, Field(max_length=200)]
+    price: Annotated[float, Field()]
+    in_stock: Annotated[bool, Field(True)]
+```
+
+Both styles are fully equivalent: they produce the same Pydantic model, the same
+DDL, and the same query behaviour. Use `Annotated` when you want to keep the type
+signature clean and the ORM metadata as a secondary annotation.
+
+### Nullability
+
+Annotate a field as `T | None` (or `Optional[T]`) when the column should be
+nullable in the database. Non-optional fields emit `NOT NULL` in the generated
+`CREATE TABLE` SQL:
+
+```python
+class User(Model):
+    id: int | None = Field(default=None)   # nullable (auto-increment PK)
+    username: str                           # NOT NULL
+    email: str | None = Field(default=None) # nullable column
 ```
 
 The primary key is the `id` field by default. To use a different primary key,
@@ -174,6 +203,33 @@ await product.save()
 order = Order(quantity=1, user_id=user.id, product_id=product.id)
 await order.save()
 ```
+
+### Serialization
+
+Every model instance exposes convenience methods for converting to plain Python
+dicts or JSON strings. By default, virtual (relation) fields are excluded so the
+output only contains database columns:
+
+```python
+user = await User.objects.get(id=1)
+
+# Serialize to dict (relation fields excluded)
+d = user.to_dict()
+# {'id': 1, 'username': 'alice', 'email': 'alice@ex.com', 'is_active': True}
+
+# Exclude None values too
+d = user.to_dict(exclude_none=True)
+
+# Serialize to JSON
+json_str = user.to_json()
+
+# Include relation fields if they were eagerly loaded
+user_with_orders = await User.objects.load_related("orders").get(id=1)
+d = user_with_orders.to_dict(exclude_virtual=False)
+```
+
+Pydantic's own `model_dump()` / `model_dump_json()` work too, with the full
+field set (including virtual fields and private attrs excluded by Pydantic).
 
 ---
 

--- a/docs/adr/0003-annotated-syntax-nullable-ddl-serialization.md
+++ b/docs/adr/0003-annotated-syntax-nullable-ddl-serialization.md
@@ -1,0 +1,57 @@
+# 0003 — Annotated field syntax, nullable DDL, and to_dict / to_json
+
+**Status:** accepted  
+**Date:** 2026-06-20
+
+## Context
+
+Two related gaps in the field system (Epic C, issues #28 and #30):
+
+1. **Annotated syntax (#30)**: Python's `Annotated[T, metadata]` is the modern, preferred way to attach type metadata without mixing a value assignment into a field declaration. Pydantic v2 supports it natively. RiverORM should too, so users can write `username: Annotated[str, Field(max_length=50)]` instead of `username: str = Field(max_length=50)`.
+
+2. **Nullable DDL (#28)**: `create_table` was not emitting `NOT NULL` for non-optional columns. That means the database would accept `NULL` where the application model rejects it — a correctness gap that could surface as data integrity issues at the DB level.
+
+3. **Serialization helpers (#28)**: Pydantic's own `model_dump()` / `model_dump_json()` work but include virtual (relation) fields by default, which are not columns and shouldn't appear in a "save to DB" or "send over the wire" serialization of a model instance.
+
+## Decision
+
+### Annotated syntax support
+
+Pydantic v2 processes `Annotated[T, FieldInfo]` transparently: the `FieldInfo` in the annotation metadata becomes the field's metadata in `model_fields`, with `field.annotation` set to `T`. Since our `Field()` wrapper embeds `FieldMeta` in `json_schema_extra`, and Pydantic preserves that, **no engine-level changes are needed** — the existing `field_meta()` function and `model_virtual_fields()` both work correctly with `Annotated`.
+
+The deliverable is test coverage (unit + integration) confirming both syntax styles are equivalent, and updated documentation showing both forms.
+
+### Nullable DDL
+
+Added `is_nullable(annotation)` to `riverorm/utils.py`. It checks:
+- `int | None` (PEP 604 `types.UnionType`)
+- `typing.Optional[int]` / `typing.Union[int, None]`
+- `type(None)` itself
+
+`create_table` now appends `NOT NULL` for every non-PK, non-nullable column. Nullable columns (and PKs, which carry their own constraints) receive no extra qualifier.
+
+Additionally, the fragile string-type detection (`hasattr(field_type, "__args__") and str in ...`) was replaced with `unwrap_type(annotation)` which strips the Optional wrapper and returns the base type. This also correctly handles `str | None` fields for VARCHAR generation.
+
+### Serialization helpers
+
+Added two instance methods to `Model`:
+
+| Method | Description |
+| --- | --- |
+| `to_dict(*, exclude_none=False, exclude_virtual=True)` | Returns a plain `dict` with relation fields excluded by default. |
+| `to_json(*, exclude_none=False, exclude_virtual=True)` | Returns a JSON `str` with relation fields excluded by default. |
+
+Both delegate to Pydantic's `model_dump()` / `model_dump_json()` with the `exclude` set computed from `model_virtual_fields()`. Private attributes (like `_persisted`) are excluded by Pydantic automatically.
+
+The default of `exclude_virtual=True` matches the most common use case (persistence, API response, logging) and avoids accidentally serializing large related-object graphs that were eagerly loaded.
+
+## Consequences
+
+**Positive**
+- Both field-declaration styles are supported and equivalent; users can migrate their models incrementally.
+- DDL now matches the application's nullability contract — inserting NULL into a `str` (non-Optional) column will be rejected by the database.
+- `to_dict()` / `to_json()` reduce boilerplate for the common "serialize this row" pattern.
+
+**Negative / obligations**
+- **Existing tables** created before this change do not have `NOT NULL` on columns that should. A schema migration is needed to add these constraints (migrations are Epic H).
+- `to_dict(exclude_virtual=False)` will include related objects **if** they were eagerly loaded; callers are responsible for ensuring related objects are serializable if they opt in.

--- a/riverorm/models.py
+++ b/riverorm/models.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import re
+import sys
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Any, ClassVar, TypeVar, get_args, get_origin
@@ -24,7 +27,7 @@ from riverorm.sql import (
     Operator,
     UpdateQuery,
 )
-from riverorm.utils import is_int_type
+from riverorm.utils import is_int_type, is_nullable, unwrap_type
 
 T = TypeVar("T", bound="Model")
 
@@ -331,8 +334,6 @@ class Model(BaseModel):
         ``user_id``). The related model is resolved from the field annotation,
         falling back to a class named like the field in the model's module.
         """
-        import sys
-
         model_fields = cls.model_real_fields()
         mod = sys.modules[cls.__module__]
         rel_map: dict[str, tuple[str, type[Model]]] = {}
@@ -482,6 +483,30 @@ class Model(BaseModel):
             obj.__dict__[root] = grouped.get(getattr(obj, pk, None), [])
         return related
 
+    def to_dict(
+        self,
+        *,
+        exclude_none: bool = False,
+        exclude_virtual: bool = True,
+    ) -> dict[str, Any]:
+        """Serialize to a plain Python dict, excluding virtual/relation fields by default."""
+        exclude: set[str] | None = (
+            set(self.__class__.model_virtual_fields()) if exclude_virtual else None
+        )
+        return self.model_dump(exclude=exclude, exclude_none=exclude_none)
+
+    def to_json(
+        self,
+        *,
+        exclude_none: bool = False,
+        exclude_virtual: bool = True,
+    ) -> str:
+        """Serialize to a JSON string, excluding virtual/relation fields by default."""
+        exclude: set[str] | None = (
+            set(self.__class__.model_virtual_fields()) if exclude_virtual else None
+        )
+        return self.model_dump_json(exclude=exclude, exclude_none=exclude_none)
+
     @classmethod
     async def create_table(cls: type[T]):
         db = cls.db()
@@ -503,9 +528,9 @@ class Model(BaseModel):
                 parts.append(dialect.auto_increment_pk(name))
                 continue
 
-            if field_type is str or (
-                hasattr(field_type, "__args__") and str in getattr(field_type, "__args__", ())
-            ):
+            # Unwrap Optional/Union to get the base type for DDL decisions.
+            base_type = unwrap_type(field_type)
+            if base_type is str:
                 length = meta.max_length or (default_pk_str_length if is_pk else None)
                 db_field_type = (
                     dialect.varchar(length) if length else dialect.python_to_sql_type(field_type)
@@ -516,6 +541,8 @@ class Model(BaseModel):
             column = f"{dialect.quote(name)} {db_field_type}"
             if is_pk:
                 column += " PRIMARY KEY"
+            elif not is_nullable(field_type):
+                column += " NOT NULL"
             parts.append(column)
         sql = f"CREATE TABLE IF NOT EXISTS {dialect.quote(cls.table_name())} ({', '.join(parts)});"
         return await db.execute(sql)

--- a/riverorm/models.py
+++ b/riverorm/models.py
@@ -1,7 +1,4 @@
-from __future__ import annotations
-
 import re
-import sys
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Any, ClassVar, TypeVar, get_args, get_origin
@@ -334,6 +331,8 @@ class Model(BaseModel):
         ``user_id``). The related model is resolved from the field annotation,
         falling back to a class named like the field in the model's module.
         """
+        import sys
+
         model_fields = cls.model_real_fields()
         mod = sys.modules[cls.__module__]
         rel_map: dict[str, tuple[str, type[Model]]] = {}
@@ -509,6 +508,15 @@ class Model(BaseModel):
 
     @classmethod
     async def create_table(cls: type[T]):
+        # Ensure forward references are resolved before inspecting model fields.
+        # A model may be incomplete when create_table() is called (before the first
+        # instance is constructed), because forward-referenced sibling classes were
+        # not yet defined when the model class body executed.
+        if not getattr(cls, "__pydantic_complete__", True):
+            import sys
+
+            mod = sys.modules.get(cls.__module__)
+            cls.model_rebuild(raise_errors=False, _types_namespace=vars(mod) if mod else None)
         db = cls.db()
         dialect = db.dialect
         parts = []

--- a/riverorm/utils.py
+++ b/riverorm/utils.py
@@ -1,16 +1,39 @@
 """Utilities for RiverORM."""
 
+from __future__ import annotations
+
 import types
+from typing import Any, Union, get_args, get_origin
 
 
-def is_int_type(ft):
-    """Check if a field type is or includes int."""
-    if ft is int:
+def is_int_type(annotation: Any) -> bool:
+    """Return True if int is (part of) this annotation, unwrapping Optional/Union."""
+    if annotation is int:
         return True
-    if hasattr(types, "UnionType") and isinstance(ft, types.UnionType):
-        return any(is_int_type(a) for a in ft.__args__ if a is not type(None))
-    origin = getattr(ft, "__origin__", None)
-    args = getattr(ft, "__args__", ())
-    if origin is not None and args:
-        return any(is_int_type(a) for a in args if a is not type(None))
+    if isinstance(annotation, types.UnionType):
+        return any(a is int for a in annotation.__args__ if a is not type(None))
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin is Union and args:
+        return any(a is int for a in args if a is not type(None))
     return False
+
+
+def is_nullable(annotation: Any) -> bool:
+    """Return True if NoneType is part of this annotation's union."""
+    if annotation is type(None):
+        return True
+    if isinstance(annotation, types.UnionType):  # int | None (PEP 604)
+        return type(None) in annotation.__args__
+    if get_origin(annotation) is Union:  # typing.Optional[int]
+        return type(None) in get_args(annotation)
+    return False
+
+
+def unwrap_type(annotation: Any) -> Any:
+    """Return the first non-None type from a Union/Optional, or the annotation itself."""
+    if isinstance(annotation, types.UnionType):
+        return next((a for a in annotation.__args__ if a is not type(None)), annotation)
+    if get_origin(annotation) is Union:
+        return next((a for a in get_args(annotation) if a is not type(None)), annotation)
+    return annotation

--- a/tests/test_annotated_and_types.py
+++ b/tests/test_annotated_and_types.py
@@ -8,6 +8,7 @@ import pytest
 
 from riverorm import Field, Model
 from riverorm.utils import is_nullable, unwrap_type
+from tests.models import User
 
 
 # ---------------------------------------------------------------------------
@@ -148,7 +149,9 @@ class TestUnwrapType:
 
 @pytest.fixture
 def db_models():
-    return [AnnotatedProduct, AnnotatedUser]
+    from tests.models import Order, Product
+
+    return [Order, Product, User, AnnotatedProduct, AnnotatedUser]
 
 
 @pytest.mark.asyncio
@@ -231,6 +234,37 @@ async def test_to_dict_after_save(db_setup_and_teardown):
     d = user.to_dict()
     assert d["id"] is not None
     assert d["username"] == "carol"
-    # Virtual fields must be absent
+
+
+@pytest.mark.asyncio
+async def test_to_dict_excludes_virtual_fields(db_setup_and_teardown):
+    """to_dict() must exclude relation fields from models that actually have them."""
+    user = User(username="dave", email="dave@ex.com", is_active=True)
+    await user.save()
+
+    # User has virtual relation fields: products and orders.
+    assert "products" in User.model_virtual_fields()
+    assert "orders" in User.model_virtual_fields()
+
+    d = user.to_dict()
     assert "products" not in d
     assert "orders" not in d
+    assert d["username"] == "dave"
+
+    # Opt-in: include virtual fields
+    d_all = user.to_dict(exclude_virtual=False)
+    assert "products" in d_all
+    assert "orders" in d_all
+
+
+@pytest.mark.asyncio
+async def test_to_json_excludes_virtual_fields(db_setup_and_teardown):
+    user = User(username="eve", email="eve@ex.com", is_active=True)
+    await user.save()
+
+    parsed = json.loads(user.to_json())
+    assert "products" not in parsed
+    assert "orders" not in parsed
+
+    parsed_all = json.loads(user.to_json(exclude_virtual=False))
+    assert "products" in parsed_all

--- a/tests/test_annotated_and_types.py
+++ b/tests/test_annotated_and_types.py
@@ -1,0 +1,236 @@
+"""Tests for Annotated field syntax (issue #30), DDL nullability (issue #28),
+and the to_dict / to_json serialization helpers (issue #28)."""
+
+import json
+from typing import Annotated
+
+import pytest
+
+from riverorm import Field, Model
+from riverorm.utils import is_nullable, unwrap_type
+
+
+# ---------------------------------------------------------------------------
+# Inline models using Annotated syntax — defined here, not in tests/models.py,
+# so they don't interfere with the shared fixture setup.
+# ---------------------------------------------------------------------------
+
+
+class AnnotatedUser(Model):
+    class Meta:
+        table_name = "annotated_users"
+
+    id: int | None = Field(default=None)
+    # Annotated-style field declarations:
+    username: Annotated[str, Field(max_length=50, unique=True)]
+    email: Annotated[str | None, Field(default=None)]
+    is_active: Annotated[bool, Field(True)]
+
+
+class AnnotatedProduct(Model):
+    class Meta:
+        table_name = "annotated_products"
+
+    id: int | None = Field(default=None)
+    name: Annotated[str, Field(max_length=200)]
+    price: Annotated[float, Field()]
+    owner_id: Annotated[int | None, Field(default=None)]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — no DB required
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotatedFieldMeta:
+    """FieldMeta is preserved when using Annotated[T, Field(...)] syntax."""
+
+    def test_max_length_is_readable(self):
+        from riverorm.fields import field_meta
+
+        field = AnnotatedUser.model_fields["username"]
+        meta = field_meta(field)
+        assert meta.max_length == 50
+
+    def test_unique_is_readable(self):
+        from riverorm.fields import field_meta
+
+        field = AnnotatedUser.model_fields["username"]
+        meta = field_meta(field)
+        assert meta.unique is True
+
+    def test_annotation_is_unwrapped_to_base_type(self):
+        # Pydantic stores the base type in .annotation, not Annotated[T, ...]
+        assert AnnotatedUser.model_fields["username"].annotation is str
+
+    def test_optional_annotation_preserved(self):
+        field = AnnotatedUser.model_fields["email"]
+        ann = field.annotation
+        # str | None
+        assert is_nullable(ann)
+        assert unwrap_type(ann) is str
+
+    def test_non_nullable_field(self):
+        field = AnnotatedUser.model_fields["username"]
+        assert not is_nullable(field.annotation)
+
+    def test_virtual_fields_not_present(self):
+        # AnnotatedUser has no virtual (relation) fields
+        assert AnnotatedUser.model_virtual_fields() == {}
+
+    def test_real_fields_include_all_scalar_fields(self):
+        real = AnnotatedUser.model_real_fields()
+        assert set(real) == {"id", "username", "email", "is_active"}
+
+
+# ---------------------------------------------------------------------------
+# is_nullable / unwrap_type unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsNullable:
+    def test_plain_type_not_nullable(self):
+        assert not is_nullable(int)
+        assert not is_nullable(str)
+        assert not is_nullable(bool)
+        assert not is_nullable(float)
+
+    def test_pep604_union_nullable(self):
+        ann = int | None
+        assert is_nullable(ann)
+
+    def test_pep604_union_not_nullable(self):
+        ann = int | str
+        assert not is_nullable(ann)
+
+    def test_none_type_itself(self):
+        assert is_nullable(type(None))
+
+    def test_typing_optional(self):
+        from typing import Optional
+
+        assert is_nullable(Optional[str])
+
+    def test_typing_union_with_none(self):
+        from typing import Union
+
+        assert is_nullable(Union[str, None])
+
+    def test_typing_union_without_none(self):
+        from typing import Union
+
+        assert not is_nullable(Union[str, int])
+
+
+class TestUnwrapType:
+    def test_unwraps_pep604_optional(self):
+        assert unwrap_type(int | None) is int
+
+    def test_unwraps_typing_optional(self):
+        from typing import Optional
+
+        assert unwrap_type(Optional[str]) is str
+
+    def test_plain_type_unchanged(self):
+        assert unwrap_type(str) is str
+
+    def test_multi_union_returns_first_non_none(self):
+        from typing import Union
+
+        result = unwrap_type(Union[str, int, None])
+        assert result is str
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require DB via db_setup_and_teardown fixture)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_models():
+    return [AnnotatedProduct, AnnotatedUser]
+
+
+@pytest.mark.asyncio
+async def test_annotated_model_create_and_fetch(db_setup_and_teardown):
+    user = AnnotatedUser(username="alice", email="alice@ex.com", is_active=True)
+    await user.save()
+
+    assert user.id is not None
+    assert user._persisted is True
+
+    fetched = await AnnotatedUser.objects.get(username="alice")
+    assert fetched.email == "alice@ex.com"
+    assert fetched.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_annotated_field_max_length_validated(db_setup_and_teardown):
+    """Pydantic enforces max_length from Annotated[str, Field(max_length=50)]."""
+    with pytest.raises(Exception):
+        AnnotatedUser(username="a" * 51, is_active=True)
+
+
+@pytest.mark.asyncio
+async def test_nullable_column_accepts_none(db_setup_and_teardown):
+    user = AnnotatedUser(username="bob", email=None, is_active=False)
+    await user.save()
+    fetched = await AnnotatedUser.objects.get(id=user.id)
+    assert fetched.email is None
+
+
+@pytest.mark.asyncio
+async def test_annotated_filter_and_order(db_setup_and_teardown):
+    await AnnotatedUser(username="alice", is_active=True).save()
+    await AnnotatedUser(username="bob", is_active=False).save()
+
+    active = await AnnotatedUser.objects.filter(is_active=True).all()
+    assert len(active) == 1
+    assert active[0].username == "alice"
+
+    ordered = await AnnotatedUser.objects.order_by("username").all()
+    assert [u.username for u in ordered] == ["alice", "bob"]
+
+
+# ---------------------------------------------------------------------------
+# to_dict / to_json
+# ---------------------------------------------------------------------------
+
+
+class TestToDictToJson:
+    def test_to_dict_includes_scalar_fields(self):
+        user = AnnotatedUser(id=1, username="alice", email="a@b.com", is_active=True)
+        d = user.to_dict()
+        assert d == {"id": 1, "username": "alice", "email": "a@b.com", "is_active": True}
+
+    def test_to_dict_exclude_none(self):
+        user = AnnotatedUser(id=None, username="alice", email=None, is_active=True)
+        d = user.to_dict(exclude_none=True)
+        assert "id" not in d
+        assert "email" not in d
+        assert d["username"] == "alice"
+
+    def test_to_json_is_valid_json(self):
+        user = AnnotatedUser(id=1, username="alice", email=None, is_active=True)
+        raw = user.to_json()
+        parsed = json.loads(raw)
+        assert parsed["username"] == "alice"
+        assert parsed["email"] is None
+
+    def test_to_json_exclude_none(self):
+        user = AnnotatedUser(id=None, username="alice", email=None, is_active=True)
+        parsed = json.loads(user.to_json(exclude_none=True))
+        assert "email" not in parsed
+        assert "id" not in parsed
+
+
+@pytest.mark.asyncio
+async def test_to_dict_after_save(db_setup_and_teardown):
+    user = AnnotatedUser(username="carol", email="carol@ex.com", is_active=True)
+    await user.save()
+    d = user.to_dict()
+    assert d["id"] is not None
+    assert d["username"] == "carol"
+    # Virtual fields must be absent
+    assert "products" not in d
+    assert "orders" not in d

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,3 +17,45 @@ async def test_create_and_fetch_user(db_setup_and_teardown):
     assert fetched.username == "Alice"
     assert fetched.email == "alice@example.com"
     assert fetched.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_save_update_path(db_setup_and_teardown):
+    user = User(username="bob", email="bob@ex.com", is_active=True)
+    await user.save()
+    original_id = user.id
+
+    user.email = "bob2@ex.com"
+    user.is_active = False
+    await user.save()
+
+    fetched = await User.objects.get(id=original_id)
+    assert fetched.email == "bob2@ex.com"
+    assert fetched.is_active is False
+    assert await User.objects.count() == 1  # no duplicate row created
+
+
+@pytest.mark.asyncio
+async def test_instance_delete(db_setup_and_teardown):
+    user = User(username="carol", email="carol@ex.com", is_active=True)
+    await user.save()
+    assert await User.objects.count() == 1
+
+    await user.delete()
+
+    assert await User.objects.count() == 0
+    assert await User.objects.filter(username="carol").exists() is False
+
+
+@pytest.mark.asyncio
+async def test_instance_delete_leaves_others_intact(db_setup_and_teardown):
+    alice = User(username="alice", email="alice@ex.com", is_active=True)
+    bob = User(username="bob", email="bob@ex.com", is_active=True)
+    await alice.save()
+    await bob.save()
+
+    await alice.delete()
+
+    remaining = await User.objects.all()
+    assert len(remaining) == 1
+    assert remaining[0].username == "bob"


### PR DESCRIPTION
## Summary

- **`Annotated[T, Field(...)]` syntax (#30)**: Now a documented, first-class alternative to the classic `field: T = Field(...)` style. Both are fully equivalent — Pydantic v2 handles `Annotated` transparently, and our `field_meta()` / DDL generation work correctly with either.
- **Nullable DDL (#28)**: `create_table` now emits `NOT NULL` for every non-PK, non-optional column. Previously the database accepted `NULL` where the model rejected it. The `is_nullable()` / `unwrap_type()` utilities replace the fragile `str in __args__` check.
- **`to_dict()` / `to_json()` (#28)**: Two new `Model` instance methods wrapping Pydantic's `model_dump` / `model_dump_json` with `exclude_virtual=True` by default, making column-only serialization a one-liner.

## What changed

| File | Change |
| --- | --- |
| `riverorm/utils.py` | Added `is_nullable()`, `unwrap_type()`; cleaned up `is_int_type()` |
| `riverorm/models.py` | `create_table` uses `unwrap_type` + emits `NOT NULL`; new `to_dict()` / `to_json()`; top-level `from __future__ import annotations` |
| `tests/test_annotated_and_types.py` | 27 test functions × 2 backends = 54 test cases |
| `docs/adr/0003-…` | ADR documenting all three decisions |
| `docs/USAGE.md` | Added Annotated syntax section, Nullability section, Serialization section |

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy .` — no issues
- [x] `uv run pytest -v` — 278 passed (both backends)
- [x] Annotated CRUD round-trip on Postgres and MySQL
- [x] `test_annotated_field_max_length_validated` — Pydantic rejects oversized input
- [x] `test_nullable_column_accepts_none` — nullable column stores NULL
- [x] `to_dict` / `to_json` exclude virtual fields and honour `exclude_none`

Closes #28, closes #30