### PR TITLE
feat(#50): only() / defer() field-subset loading

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -265,6 +265,8 @@ orders = await Order.objects.select_related("user").filter(status="paid").order_
 | `limit(n)` / `offset(n)` | Slice the result set. |
 | `select_related(*fields)` | Eager-load forward relations via a `JOIN`. |
 | `load_related(*fields)` | Batched eager loading (forward / reverse / nested). |
+| `only(*fields)` | SELECT only the named columns (partial load). |
+| `defer(*fields)` | SELECT all columns *except* the named ones (partial load). |
 
 ### Terminal methods (await these)
 
@@ -284,6 +286,51 @@ n = await Product.objects.filter(in_stock=True).count()
 if await User.objects.filter(username="alice").exists():
     ...
 ```
+
+### Field-subset loading (`only` / `defer`)
+
+`only()` fetches only the named columns; `defer()` fetches everything *except*
+the named columns.  Use `Model.f.field_name` for typed, rename-safe field
+references — typos raise `AttributeError` at the call site rather than
+producing a SQL error.  Plain strings are accepted too.
+
+```python
+f = User.f  # typed field-reference namespace
+
+# Include only these columns
+users = await User.objects.only(f.id, f.username).filter(is_active=True).all()
+
+# Exclude columns (fetch everything else)
+products = await Product.objects.defer(f.description).order_by("name").all()
+
+# Plain strings are accepted too (backward-compatible)
+users = await User.objects.only("id", "username").all()
+
+# Shorthand via the model class
+users = await User.only(f.id, f.username).all()
+users = await User.defer(f.email).all()
+```
+
+Instances returned from partial queries are created with Pydantic's
+`model_construct` (no validation). Columns that were not fetched carry their
+Python-level defaults (`None`, `True`, `[]`, etc.), **not** the actual DB values.
+The primary key is always loaded (even if you omit it from `only()` or name it
+in `defer()`), so partial instances stay identity-safe.
+
+Calling `.save()` on a partial instance is safe: the UPDATE is confined to the
+columns that were actually fetched, so un-fetched columns keep their stored DB
+values instead of being overwritten with defaults. Pass `update_fields` to
+write a specific subset explicitly (works on any instance, partial or not):
+
+```python
+user = await User.objects.only(f.id, f.username).get(id=1)
+user.username = "renamed"
+await user.save()                         # UPDATE users SET username=… WHERE id=1
+await user.save(update_fields=["username"])  # same, explicit
+```
+
+Both `only()` and `defer()` raise `ValueError` immediately if you name a field
+that does not exist as a real (non-relation) column on the model.
 
 All database operations are async. To create, update, or delete a single row,
 use the instance methods or the `objects` API:

--- a/docs/adr/0004-only-defer-field-subset-loading.md
+++ b/docs/adr/0004-only-defer-field-subset-loading.md
@@ -1,0 +1,87 @@
+# 0004 — `only()` / `defer()` field-subset loading
+
+| Field | Value |
+|---|---|
+| **Status** | accepted |
+| **Date** | 2026-06-20 |
+
+## Context
+
+Full-table `SELECT *` queries are wasteful when callers only need a handful of
+columns (listing UIs, large text blobs on hot paths, etc.). Issue #50 tracks
+the requirement. The original draft implemented `only()` accepting plain
+strings, but untyped string literals silently break when models are refactored.
+
+## Decision
+
+Introduce two chaining methods — `only()` and `defer()` — and a typed
+`FieldRef` value so callers can reference fields as Python attributes rather
+than bare strings:
+
+```python
+f = User.f
+await User.objects.only(f.id, f.username).all()   # include subset
+await User.objects.defer(f.email).all()            # exclude subset
+await User.objects.only("id", "username").all()    # strings still work
+```
+
+**`FieldRef`** (`riverorm.fields`) is a frozen dataclass holding a field name.
+It has no negation or `excluded` flag — `only()` and `defer()` are separate
+methods with distinct semantics, not a single function with signed refs.
+
+**`FieldsNamespace`** / **`_FieldsDescriptor`** (`riverorm.models`) expose
+`Model.f` as a lazy descriptor. `Model.f.field_name` returns `FieldRef(field_name)`;
+unknown or virtual (relation) fields raise `AttributeError` immediately at the
+call site.
+
+**`QuerySet.only(*fields)`** stores a positive `only_fields` tuple; SQL uses
+`SELECT col1, col2 …`.
+
+**`QuerySet.defer(*fields)`** stores a `defer_fields` tuple; SQL expands to
+all real fields minus the deferred ones at query-build time.
+
+Both methods validate names against `model_real_fields()` and raise
+`ValueError` immediately for unknown or virtual fields. Setting one clears the
+other (they are mutually exclusive per query).
+
+The **primary key is always loaded**, even when `only()` omits it or `defer()`
+names it — mirroring Django. This keeps partial instances identity-safe so
+`save()` / `delete()` work and the PK is never silently lost.
+
+Plain strings are accepted and coerced to `FieldRef` internally for
+backward compatibility.
+
+**SQL layer** — `SelectQuery.columns` already accepted an explicit column tuple
+(empty = `SELECT *`). No SQL-layer changes were needed.
+
+**Partial instantiation** — rows missing columns use `Model.model_construct()`
+(bypasses Pydantic validation; Python-level defaults fill un-fetched optional
+fields). The resulting instances are marked `_persisted = True` and record the
+fetched columns in `_loaded_fields`.
+
+**Save safety** — `save()` on a partial instance restricts its UPDATE to the
+loaded columns (the PK is the WHERE key and never in the SET list), so
+un-fetched columns are not overwritten with their Python defaults. `save()`
+gained an `update_fields` argument to write an explicit subset on any instance.
+
+## Consequences
+
+- Field references checked against `model_real_fields()` at call time → typos
+  surface as `AttributeError` / `ValueError` at the line that builds the query,
+  not buried in SQL errors.
+- IDEs that honour `__dir__` may show real field names as autocomplete
+  suggestions on `Model.f`. Full static checking (mypy/pyright) cannot verify
+  attribute names without a plugin; `Model.f.nonexistent` is a runtime error,
+  not a type error.
+- `model_construct` skips Pydantic coercion. MySQL `BOOLEAN` columns arrive as
+  `1`/`0` integers on partial rows; code that checks `is True` instead of
+  truthiness will see a difference.
+- `only()` / `defer()` do not compose with `select_related()`: the JOIN path
+  builds its own column list. Combining them raises `ValueError` at execution
+  rather than silently ignoring the column restriction.
+- Required fields (no default) that are excluded will not be set as attributes;
+  accessing them raises `AttributeError`. The primary key is exempt — it is
+  always fetched.
+- Saving a partial instance writes only its loaded columns. Setting an
+  un-fetched attribute and calling `save()` without naming it in
+  `update_fields` will therefore not persist that change.

--- a/riverorm/__init__.py
+++ b/riverorm/__init__.py
@@ -2,5 +2,6 @@ from __future__ import annotations
 
 from .fields import Field as Field
 from .fields import FieldMeta as FieldMeta
+from .fields import FieldRef as FieldRef
 from .models import Model as Model
 from .models import PrimaryKeyError as PrimaryKeyError

--- a/riverorm/fields.py
+++ b/riverorm/fields.py
@@ -12,6 +12,7 @@ upcoming features such as relationships, indexes/constraints, and migrations.
 
 from __future__ import annotations
 
+import dataclasses
 import warnings
 from dataclasses import dataclass
 from typing import Any
@@ -94,6 +95,28 @@ def Field(  # noqa: N802 - mirrors pydantic.Field's callable-as-name convention
         kwargs.setdefault("max_length", max_length)
 
     return _PydanticField(default, **kwargs)
+
+
+@dataclasses.dataclass(frozen=True)
+class FieldRef:
+    """A typed reference to a model field for use in ``only()`` / ``defer()``.
+
+    Obtained via the ``Model.f`` namespace, which validates that the name is a
+    real DB column (not a relation) and raises ``AttributeError`` immediately
+    for typos or renamed fields::
+
+        User.f.username  # → FieldRef("username")
+        User.f.email     # → FieldRef("email")
+
+    Pass to :meth:`~riverorm.queryset.QuerySet.only` or
+    :meth:`~riverorm.queryset.QuerySet.defer` for rename-safe query construction.
+    Plain strings are also accepted by both methods.
+    """
+
+    name: str
+
+    def __repr__(self) -> str:
+        return f"FieldRef({self.name!r})"
 
 
 def field_meta(field: FieldInfo) -> FieldMeta:

--- a/riverorm/models.py
+++ b/riverorm/models.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, PrivateAttr
 from pydantic.fields import FieldInfo
 
 from riverorm import constants
-from riverorm.fields import Field, FieldMeta, field_meta
+from riverorm.fields import Field, FieldMeta, FieldRef, field_meta
 from riverorm.db import BaseDatabase, DatabaseRegistry
 from riverorm.queryset import (
     DoesNotExist,
@@ -87,6 +87,45 @@ def _ensure_model_complete(model: type[Model]) -> None:
     model.model_rebuild(raise_errors=True, _types_namespace=ns)
 
 
+class FieldsNamespace:
+    """Field-reference namespace returned by ``Model.f``.
+
+    Attribute access returns a :class:`~riverorm.fields.FieldRef` for each real DB
+    column.  Use the result in :meth:`~riverorm.queryset.QuerySet.only`::
+
+        await User.objects.only(User.f.username, User.f.email).all()
+
+    Accessing a non-existent or virtual (relation) field raises ``AttributeError``
+    immediately, so typos and renamed fields are caught at the call site.
+    """
+
+    __slots__ = ("_model",)
+
+    def __init__(self, model: type) -> None:
+        object.__setattr__(self, "_model", model)
+
+    def __getattr__(self, name: str) -> FieldRef:
+        model: type = object.__getattribute__(self, "_model")
+        real = model.model_real_fields()  # type: ignore[attr-defined]
+        if name not in real:
+            raise AttributeError(
+                f"{model.__name__} has no real field '{name}'. "  # type: ignore[attr-defined]
+                f"Available: {sorted(real)}"
+            )
+        return FieldRef(name)
+
+    def __dir__(self) -> list[str]:
+        model: type = object.__getattribute__(self, "_model")
+        return list(model.model_real_fields())  # type: ignore[attr-defined]
+
+
+class _FieldsDescriptor:
+    """Descriptor that yields a :class:`FieldsNamespace` on class (or instance) access."""
+
+    def __get__(self, obj: object, owner: type | None = None) -> FieldsNamespace:
+        return FieldsNamespace(owner if owner is not None else type(obj))
+
+
 class Model(BaseModel):
     """
     Base model class for River ORM.
@@ -129,8 +168,16 @@ class Model(BaseModel):
     #: the INSERT-vs-UPDATE decision in :meth:`save` for non-auto-increment PKs.
     _persisted: bool = PrivateAttr(default=False)
 
+    #: Columns actually fetched for a partially-loaded instance (``only()`` /
+    #: ``defer()``); ``None`` means the row was loaded in full. ``save()`` only
+    #: writes these columns so un-fetched ones are never clobbered with defaults.
+    _loaded_fields: set[str] | None = PrivateAttr(default=None)
+
     #: Entry point to the chainable query API: ``User.objects.filter(...)``.
     objects: ClassVar[ManagerDescriptor] = ManagerDescriptor()
+
+    #: Field-reference namespace for typed use in ``only()``: ``User.f.username``.
+    f: ClassVar[_FieldsDescriptor] = _FieldsDescriptor()
 
     #: Raised by ``get()`` when no row matches / more than one row matches.
     DoesNotExist: ClassVar[type[Exception]] = DoesNotExist
@@ -159,6 +206,19 @@ class Model(BaseModel):
         """Build an instance from a fetched DB row and mark it as persisted."""
         obj = cls(**data)
         obj._persisted = True
+        return obj
+
+    @classmethod
+    def _from_partial_row(cls: type[T], data: dict[str, Any]) -> T:
+        """Build an instance from a partial DB row without validation.
+
+        Used by ``only()`` / ``defer()`` queries where only a column subset is
+        fetched. Pydantic's ``model_construct`` skips validation and applies
+        field defaults for any columns that were not selected.
+        """
+        obj = cls.model_construct(**data)
+        obj._persisted = True
+        obj._loaded_fields = set(data)
         return obj
 
     @classmethod
@@ -253,8 +313,15 @@ class Model(BaseModel):
             conditions.append(Condition(Column(field), operator, value))
         return tuple(conditions)
 
-    async def save(self) -> Self:
-        """Persist this instance (INSERT if new, UPDATE if already saved)."""
+    async def save(self, update_fields: list[str] | None = None) -> Self:
+        """Persist this instance (INSERT if new, UPDATE if already saved).
+
+        ``update_fields`` restricts an UPDATE to the named columns. For a
+        partially-loaded instance (from ``only()`` / ``defer()``) the UPDATE is
+        confined to the columns that were actually fetched, so un-fetched fields
+        are never overwritten with their Python defaults; pass ``update_fields``
+        to write a different subset.
+        """
         db = self.db()
         compiler = db.compiler
         fields = list(self.__class__.model_real_fields().keys())
@@ -294,18 +361,43 @@ class Model(BaseModel):
                 if new_pk is not None and getattr(self, pk_name, None) is None:
                     setattr(self, pk_name, new_pk)
         else:
-            # UPDATE
-            values = tuple(getattr(self, f) for f in fields)
-            update = UpdateQuery(
-                table=self.table_name(),
-                columns=tuple(fields),
-                values=values,
-                where=(Condition(Column(pk_name), Operator.EQ, pk),),
-            )
-            sql, params = compiler.compile_update(update)
-            await db.update(sql, *params)
+            # UPDATE — write only the relevant columns (never the PK, which is the
+            # WHERE key). Defaults to the explicitly named or loaded subset so a
+            # partial instance can't clobber un-fetched columns.
+            write_fields = self._save_columns(fields, pk_name, update_fields)
+            if write_fields:
+                values = tuple(getattr(self, f) for f in write_fields)
+                update = UpdateQuery(
+                    table=self.table_name(),
+                    columns=tuple(write_fields),
+                    values=values,
+                    where=(Condition(Column(pk_name), Operator.EQ, pk),),
+                )
+                sql, params = compiler.compile_update(update)
+                await db.update(sql, *params)
         self._persisted = True
         return self
+
+    def _save_columns(
+        self, fields: list[str], pk_name: str, update_fields: list[str] | None
+    ) -> list[str]:
+        """Resolve which columns an UPDATE should write (PK always excluded).
+
+        Precedence: explicit ``update_fields`` → the loaded subset of a partial
+        instance → all columns.
+        """
+        if update_fields is not None:
+            unknown = set(update_fields) - set(fields)
+            if unknown:
+                raise ValueError(
+                    f"Unknown update_fields for {type(self).__name__}: {sorted(unknown)}"
+                )
+            selected: set[str] | None = set(update_fields)
+        elif self._loaded_fields is not None:
+            selected = self._loaded_fields
+        else:
+            selected = None
+        return [f for f in fields if f != pk_name and (selected is None or f in selected)]
 
     async def delete(self) -> None:
         pk_name = self.primary_key()
@@ -455,6 +547,30 @@ class Model(BaseModel):
             orders = await Order.load_related("user", "product__user").filter(status="paid")
         """
         return cls.objects.load_related(*related_fields)
+
+    @classmethod
+    def only(cls: type[T], *fields: str | FieldRef) -> QuerySet[T]:
+        """Return a :class:`QuerySet` that SELECTs only the named fields.
+
+        Example::
+
+            f = User.f
+            await User.only(f.id, f.username).filter(is_active=True).all()
+            await User.only("id", "username").all()  # string form
+        """
+        return cls.objects.only(*fields)
+
+    @classmethod
+    def defer(cls: type[T], *fields: str | FieldRef) -> QuerySet[T]:
+        """Return a :class:`QuerySet` that SELECTs all fields *except* the named ones.
+
+        Example::
+
+            f = User.f
+            await User.defer(f.email).all()
+            await User.defer("email").all()  # string form
+        """
+        return cls.objects.defer(*fields)
 
     @classmethod
     async def _prefetch_related(cls, objects: Sequence[Model], specs: list[str]) -> None:

--- a/riverorm/queryset.py
+++ b/riverorm/queryset.py
@@ -20,6 +20,7 @@ import dataclasses
 from collections.abc import AsyncIterator, Generator
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
+from riverorm.fields import FieldRef
 from riverorm.sql import Column, Condition, DeleteQuery, OrderBy, SelectQuery, UpdateQuery
 
 if TYPE_CHECKING:
@@ -54,6 +55,8 @@ class QuerySet(Generic[T]):
     offset_value: int | None = None
     select_related_fields: tuple[str, ...] = ()
     load_related_fields: tuple[str, ...] = ()
+    only_fields: tuple[str, ...] = ()
+    defer_fields: tuple[str, ...] = ()
 
     # -- chaining (all return a fresh QuerySet) -----------------------------
 
@@ -98,6 +101,60 @@ class QuerySet(Generic[T]):
     def load_related(self, *fields: str) -> QuerySet[T]:
         """Return a new ``QuerySet`` that prefetches the given relations."""
         return dataclasses.replace(self, load_related_fields=self.load_related_fields + fields)
+
+    def only(self, *fields: str | FieldRef) -> QuerySet[T]:
+        """Return a new ``QuerySet`` that SELECTs only the named fields.
+
+        Pass :class:`~riverorm.fields.FieldRef` objects (via ``Model.f``) for
+        rename-safe references, or plain strings for convenience::
+
+            f = User.f
+            await User.objects.only(f.id, f.username).all()
+            await User.objects.only("id", "username").all()  # string form
+
+        Instances from partial queries use :meth:`~pydantic.BaseModel.model_construct`
+        (no validation). Un-fetched optional fields carry their Python defaults;
+        un-fetched required fields will not be set on the instance.
+        """
+        if not fields:
+            return dataclasses.replace(self, only_fields=(), defer_fields=())
+        names = self._validate_field_refs(fields, "only")
+        return dataclasses.replace(self, only_fields=names, defer_fields=())
+
+    def defer(self, *fields: str | FieldRef) -> QuerySet[T]:
+        """Return a new ``QuerySet`` that SELECTs all fields *except* the named ones.
+
+        Pass :class:`~riverorm.fields.FieldRef` objects (via ``Model.f``) for
+        rename-safe references, or plain strings for convenience::
+
+            f = User.f
+            await User.objects.defer(f.email).all()
+            await User.objects.defer("email").all()  # string form
+
+        Instances from partial queries use :meth:`~pydantic.BaseModel.model_construct`
+        (no validation). Deferred optional fields carry their Python defaults;
+        deferred required fields will not be set on the instance.
+        """
+        if not fields:
+            return dataclasses.replace(self, defer_fields=(), only_fields=())
+        names = self._validate_field_refs(fields, "defer")
+        return dataclasses.replace(self, defer_fields=names, only_fields=())
+
+    def _validate_field_refs(
+        self, fields: tuple[str | FieldRef, ...], method: str
+    ) -> tuple[str, ...]:
+        """Coerce ``only()`` / ``defer()`` arguments to validated column names.
+
+        Accepts strings or :class:`~riverorm.fields.FieldRef` values and raises
+        ``ValueError`` if any name is not a real (non-relation) column.
+        """
+        names = tuple(f if isinstance(f, str) else f.name for f in fields)
+        unknown = set(names) - set(self.model.model_real_fields())
+        if unknown:
+            raise ValueError(
+                f"Unknown fields for {method}() on {self.model.__name__}: {sorted(unknown)}"
+            )
+        return names
 
     # -- terminals ----------------------------------------------------------
 
@@ -173,8 +230,20 @@ class QuerySet(Generic[T]):
     # -- execution ----------------------------------------------------------
 
     def _build_query(self) -> SelectQuery:
+        if self.only_fields:
+            # Always load the primary key so partial instances stay identity-safe
+            # (save()/delete() rely on it), mirroring Django's only()/defer().
+            pk = self.model.primary_key()
+            names = self.only_fields if pk in self.only_fields else (pk, *self.only_fields)
+            columns: tuple[Column, ...] = tuple(Column(f) for f in names)
+        elif self.defer_fields:
+            skipped = set(self.defer_fields) - {self.model.primary_key()}
+            columns = tuple(Column(f) for f in self.model.model_real_fields() if f not in skipped)
+        else:
+            columns = ()
         return SelectQuery(
             table=self.model.table_name(),
+            columns=columns,
             where=self.where,
             order_by=self.order,
             limit=self.limit_value,
@@ -183,11 +252,19 @@ class QuerySet(Generic[T]):
 
     async def _execute(self) -> list[T]:
         if self.select_related_fields:
+            if self.only_fields or self.defer_fields:
+                raise ValueError(
+                    "only() / defer() cannot be combined with select_related(); "
+                    "the JOIN builds its own column list. Drop one of them."
+                )
             return await self._execute_select_related()
         db = self.model.db()
         sql, params = db.compiler.compile_select(self._build_query())
         rows = await db.fetch(sql, *params)
-        objects = [self.model._from_row(dict(row)) for row in rows]
+        if self.only_fields or self.defer_fields:
+            objects = [self.model._from_partial_row(dict(row)) for row in rows]
+        else:
+            objects = [self.model._from_row(dict(row)) for row in rows]
         if self.load_related_fields:
             await self.model._prefetch_related(objects, list(self.load_related_fields))
         return objects
@@ -267,6 +344,12 @@ class Manager(Generic[T]):
 
     def load_related(self, *fields: str) -> QuerySet[T]:
         return self.get_queryset().load_related(*fields)
+
+    def only(self, *fields: str | FieldRef) -> QuerySet[T]:
+        return self.get_queryset().only(*fields)
+
+    def defer(self, *fields: str | FieldRef) -> QuerySet[T]:
+        return self.get_queryset().defer(*fields)
 
     async def all(self) -> list[T]:
         return await self.get_queryset().all()

--- a/tests/test_field_subset.py
+++ b/tests/test_field_subset.py
@@ -1,0 +1,366 @@
+"""Tests for QuerySet.only() and QuerySet.defer() with typed FieldRef / Model.f."""
+
+from __future__ import annotations
+
+import pytest
+
+from riverorm import FieldRef
+from tests.models import Order, Product, User
+
+
+@pytest.fixture
+def db_models() -> list[type]:
+    return [Order, Product, User]
+
+
+# ---------------------------------------------------------------------------
+# FieldRef unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_field_ref_stores_name():
+    ref = FieldRef("username")
+    assert ref.name == "username"
+
+
+def test_field_ref_repr():
+    assert repr(FieldRef("username")) == "FieldRef('username')"
+
+
+# ---------------------------------------------------------------------------
+# FieldsNamespace (Model.f) unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_model_f_returns_field_ref():
+    ref = User.f.username
+    assert isinstance(ref, FieldRef)
+    assert ref.name == "username"
+
+
+def test_model_f_unknown_field_raises():
+    with pytest.raises(AttributeError, match="no real field"):
+        _ = User.f.nonexistent
+
+
+def test_model_f_virtual_field_raises():
+    with pytest.raises(AttributeError, match="no real field"):
+        _ = User.f.products
+
+
+def test_model_f_dir_lists_real_fields():
+    names = dir(User.f)
+    assert "id" in names
+    assert "username" in names
+    assert "email" in names
+    assert "is_active" in names
+    assert "products" not in names
+    assert "orders" not in names
+
+
+# ---------------------------------------------------------------------------
+# QuerySet.only() unit tests (no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_only_stores_field_names():
+    qs = User.objects.only(User.f.id, User.f.username)
+    assert qs.only_fields == ("id", "username")
+    assert qs.defer_fields == ()
+
+
+def test_only_string_backward_compat():
+    qs = User.objects.only("id", "username")
+    assert qs.only_fields == ("id", "username")
+
+
+def test_only_clears_defer():
+    qs = User.objects.defer(User.f.email).only(User.f.id, User.f.username)
+    assert qs.only_fields == ("id", "username")
+    assert qs.defer_fields == ()
+
+
+def test_only_empty_args_clears():
+    qs = User.objects.only(User.f.username).only()
+    assert qs.only_fields == ()
+
+
+def test_only_rejects_unknown_field_ref():
+    with pytest.raises(ValueError, match="Unknown fields for only"):
+        User.objects.only(FieldRef("nonexistent"))
+
+
+def test_only_rejects_unknown_string():
+    with pytest.raises(ValueError, match="Unknown fields for only"):
+        User.objects.only("nonexistent_field")
+
+
+def test_only_rejects_virtual_field():
+    with pytest.raises(ValueError, match="Unknown fields for only"):
+        User.objects.only("products")
+
+
+# ---------------------------------------------------------------------------
+# QuerySet.defer() unit tests (no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_defer_stores_field_names():
+    qs = User.objects.defer(User.f.email)
+    assert qs.defer_fields == ("email",)
+    assert qs.only_fields == ()
+
+
+def test_defer_string_backward_compat():
+    qs = User.objects.defer("email")
+    assert qs.defer_fields == ("email",)
+
+
+def test_defer_clears_only():
+    qs = User.objects.only(User.f.id, User.f.username).defer(User.f.email)
+    assert qs.defer_fields == ("email",)
+    assert qs.only_fields == ()
+
+
+def test_defer_empty_args_clears():
+    qs = User.objects.defer(User.f.email).defer()
+    assert qs.defer_fields == ()
+
+
+def test_defer_rejects_unknown_field_ref():
+    with pytest.raises(ValueError, match="Unknown fields for defer"):
+        User.objects.defer(FieldRef("nonexistent"))
+
+
+def test_defer_rejects_unknown_string():
+    with pytest.raises(ValueError, match="Unknown fields for defer"):
+        User.objects.defer("nonexistent_field")
+
+
+def test_defer_rejects_virtual_field():
+    with pytest.raises(ValueError, match="Unknown fields for defer"):
+        User.objects.defer("orders")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_only_loads_named_fields(db_setup_and_teardown):
+    await User(username="alice", email="alice@ex.com", is_active=True).save()
+
+    users = await User.objects.only(User.f.id, User.f.username).all()
+
+    assert len(users) == 1
+    assert users[0].username == "alice"
+    assert users[0].id is not None
+
+
+@pytest.mark.asyncio
+async def test_only_always_loads_primary_key(db_setup_and_teardown):
+    # PK is loaded even when not named, so the instance stays identity-safe.
+    await User(username="alice", email="alice@ex.com", is_active=True).save()
+
+    users = await User.objects.only(User.f.username).all()
+
+    assert users[0].id is not None
+
+
+@pytest.mark.asyncio
+async def test_defer_never_drops_primary_key(db_setup_and_teardown):
+    # Deferring the PK is ignored — it is always fetched.
+    await User(username="alice", email="alice@ex.com", is_active=True).save()
+
+    users = await User.objects.defer(User.f.id, User.f.email).all()
+
+    assert users[0].id is not None
+
+
+@pytest.mark.asyncio
+async def test_only_result_is_persisted(db_setup_and_teardown):
+    await User(username="alice", email="alice@ex.com", is_active=True).save()
+
+    users = await User.objects.only(User.f.id, User.f.username).all()
+
+    assert users[0]._persisted is True
+
+
+@pytest.mark.asyncio
+async def test_defer_excludes_named_field(db_setup_and_teardown):
+    await User(username="bob", email="bob@ex.com", is_active=True).save()
+
+    users = await User.objects.defer(User.f.email).all()
+
+    assert len(users) == 1
+    assert users[0].username == "bob"
+    assert users[0].email is None  # default applied for un-fetched optional field
+
+
+@pytest.mark.asyncio
+async def test_defer_result_is_persisted(db_setup_and_teardown):
+    await User(username="bob", email="bob@ex.com", is_active=True).save()
+
+    users = await User.objects.defer(User.f.email).all()
+
+    assert users[0]._persisted is True
+
+
+@pytest.mark.asyncio
+async def test_only_composes_with_filter(db_setup_and_teardown):
+    await User(username="alice", email="alice@ex.com", is_active=True).save()
+    await User(username="bob", email="bob@ex.com", is_active=False).save()
+
+    users = await User.objects.only(User.f.id, User.f.username).filter(is_active=True).all()
+
+    assert len(users) == 1
+    assert users[0].username == "alice"
+
+
+@pytest.mark.asyncio
+async def test_defer_composes_with_filter(db_setup_and_teardown):
+    await User(username="alice", email="alice@ex.com", is_active=True).save()
+    await User(username="bob", email="bob@ex.com", is_active=False).save()
+
+    users = await User.objects.defer(User.f.email).filter(is_active=False).all()
+
+    assert len(users) == 1
+    assert users[0].username == "bob"
+
+
+@pytest.mark.asyncio
+async def test_only_composes_with_order_by(db_setup_and_teardown):
+    await User(username="charlie", email="c@ex.com", is_active=True).save()
+    await User(username="alice", email="a@ex.com", is_active=True).save()
+
+    users = await User.objects.only(User.f.id, User.f.username).order_by("username").all()
+
+    assert [u.username for u in users] == ["alice", "charlie"]
+
+
+@pytest.mark.asyncio
+async def test_only_first(db_setup_and_teardown):
+    await User(username="carol", email="carol@ex.com", is_active=True).save()
+
+    user = await User.objects.only(User.f.id, User.f.username).first()
+
+    assert user is not None
+    assert user.username == "carol"
+
+
+@pytest.mark.asyncio
+async def test_defer_multiple_fields(db_setup_and_teardown):
+    await User(username="alice", email="alice@ex.com", is_active=True).save()
+
+    users = await User.objects.defer(User.f.email, User.f.is_active).all()
+
+    assert len(users) == 1
+    assert users[0].username == "alice"
+    assert users[0].id is not None
+
+
+@pytest.mark.asyncio
+async def test_only_via_model_classmethod(db_setup_and_teardown):
+    await User(username="dave", email="dave@ex.com", is_active=True).save()
+
+    users = await User.only(User.f.id, User.f.username).all()
+
+    assert users[0].username == "dave"
+
+
+@pytest.mark.asyncio
+async def test_defer_via_model_classmethod(db_setup_and_teardown):
+    await User(username="eve", email="eve@ex.com", is_active=True).save()
+
+    users = await User.defer(User.f.email).all()
+
+    assert users[0].username == "eve"
+
+
+@pytest.mark.asyncio
+async def test_only_string_compat_integration(db_setup_and_teardown):
+    await User(username="alice", email="alice@ex.com", is_active=True).save()
+
+    users = await User.objects.only("id", "username").all()
+
+    assert users[0].username == "alice"
+
+
+@pytest.mark.asyncio
+async def test_defer_string_compat_integration(db_setup_and_teardown):
+    await User(username="bob", email="bob@ex.com", is_active=True).save()
+
+    users = await User.objects.defer("email").all()
+
+    assert users[0].username == "bob"
+
+
+@pytest.mark.asyncio
+async def test_only_count_uses_full_query(db_setup_and_teardown):
+    await User(username="alice", email="alice@ex.com", is_active=True).save()
+    await User(username="bob", email="bob@ex.com", is_active=False).save()
+
+    count = await User.objects.only(User.f.id, User.f.username).count()
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_only_exists(db_setup_and_teardown):
+    await User(username="alice", email="alice@ex.com", is_active=True).save()
+
+    assert await User.objects.only(User.f.id).exists() is True
+
+
+# ---------------------------------------------------------------------------
+# Saving partially-loaded instances must not clobber un-fetched columns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_partial_does_not_clobber_unfetched(db_setup_and_teardown):
+    await User(username="alice", email="alice@ex.com", is_active=True).save()
+
+    partial = await User.objects.only(User.f.username).first()
+    partial.username = "alice2"
+    await partial.save()
+
+    # email / is_active were never fetched, so they must survive the save.
+    full = await User.objects.get(username="alice2")
+    assert full.email == "alice@ex.com"
+    assert full.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_save_update_fields_writes_only_named(db_setup_and_teardown):
+    await User(username="bob", email="bob@ex.com", is_active=True).save()
+
+    user = await User.objects.get(username="bob")
+    user.username = "bob2"
+    user.email = "ignored@ex.com"
+    await user.save(update_fields=["username"])
+
+    full = await User.objects.get(username="bob2")
+    assert full.email == "bob@ex.com"  # email change was not written
+
+
+@pytest.mark.asyncio
+async def test_save_update_fields_unknown_raises(db_setup_and_teardown):
+    await User(username="carol", email="carol@ex.com", is_active=True).save()
+
+    user = await User.objects.get(username="carol")
+    with pytest.raises(ValueError, match="Unknown update_fields"):
+        await user.save(update_fields=["nope"])
+
+
+@pytest.mark.asyncio
+async def test_only_with_select_related_raises(db_setup_and_teardown):
+    # Silently ignoring the column restriction would surprise callers; be explicit.
+    with pytest.raises(ValueError, match="cannot be combined with select_related"):
+        await Order.objects.only(Order.f.id).select_related("user").all()
+
+
+@pytest.mark.asyncio
+async def test_defer_with_select_related_raises(db_setup_and_teardown):
+    with pytest.raises(ValueError, match="cannot be combined with select_related"):
+        await Order.objects.defer(Order.f.quantity).select_related("user").all()

--- a/tests/test_pydantic_compat.py
+++ b/tests/test_pydantic_compat.py
@@ -1,0 +1,317 @@
+"""Pydantic compatibility tests for RiverORM's Model base class.
+
+These tests verify that Model (which extends BaseModel) does not break any
+expected Pydantic behaviour: instance access, validation, serialization, copy,
+custom validators, inheritance, PrivateAttr, and ClassVar fields.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import pytest
+from pydantic import ValidationError, field_validator, model_validator
+from pydantic.fields import FieldInfo
+
+from riverorm import Field, Model
+
+
+# ---------------------------------------------------------------------------
+# Test models
+# ---------------------------------------------------------------------------
+
+
+class Simple(Model):
+    id: int | None = Field(default=None)
+    name: str = Field(...)
+    score: float = Field(default=0.0)
+    active: bool = Field(True)
+    tags: list[str] = Field(default_factory=list)
+    notes: str | None = Field(default=None)
+
+
+class WithValidator(Model):
+    id: int | None = Field(default=None)
+    username: str = Field(...)
+    email: str = Field(...)
+
+    @field_validator("username")
+    @classmethod
+    def username_lower(cls, v: str) -> str:
+        return v.lower()
+
+    @model_validator(mode="after")
+    def email_contains_at(self) -> WithValidator:
+        if "@" not in self.email:
+            raise ValueError("email must contain @")
+        return self
+
+
+class Parent(Model):
+    id: int | None = Field(default=None)
+    base_field: str = Field(...)
+
+
+class Child(Parent):
+    child_field: int = Field(default=42)
+
+
+class WithClassVar(Model):
+    id: int | None = Field(default=None)
+    data: str = Field(...)
+    CLASS_CONSTANT: ClassVar[str] = "constant"
+    objects_count: ClassVar[int] = 0
+
+
+# ---------------------------------------------------------------------------
+# Instance attribute access
+# ---------------------------------------------------------------------------
+
+
+class TestInstanceAccess:
+    def test_required_field_read(self):
+        obj = Simple(name="test")
+        assert obj.name == "test"
+
+    def test_optional_field_defaults_to_none(self):
+        obj = Simple(name="test")
+        assert obj.notes is None
+
+    def test_default_scalar(self):
+        obj = Simple(name="test")
+        assert obj.score == 0.0
+        assert obj.active is True
+
+    def test_default_factory(self):
+        obj = Simple(name="test")
+        assert obj.tags == []
+
+    def test_provided_values(self):
+        obj = Simple(name="Alice", score=9.5, active=False, tags=["a", "b"], notes="hi")
+        assert obj.name == "Alice"
+        assert obj.score == 9.5
+        assert obj.active is False
+        assert obj.tags == ["a", "b"]
+        assert obj.notes == "hi"
+
+    def test_field_mutation_updates_value(self):
+        obj = Simple(name="old")
+        obj.name = "new"
+        assert obj.name == "new"
+
+    def test_id_defaults_none(self):
+        assert Simple(name="test").id is None
+
+    def test_id_set_explicitly(self):
+        assert Simple(id=42, name="test").id == 42
+
+    def test_two_instances_independent(self):
+        a = Simple(name="alice")
+        b = Simple(name="bob")
+        assert a.name == "alice"
+        assert b.name == "bob"
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_required_field_missing_raises(self):
+        with pytest.raises(ValidationError) as exc_info:
+            Simple()  # type: ignore[call-arg]
+        fields = {e["loc"][0] for e in exc_info.value.errors()}
+        assert "name" in fields
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(ValidationError):
+            Simple(name="x", score="not-a-float")
+
+    def test_field_validator_runs(self):
+        obj = WithValidator(username="ALICE", email="a@b.com")
+        assert obj.username == "alice"
+
+    def test_model_validator_runs(self):
+        with pytest.raises(ValidationError):
+            WithValidator(username="alice", email="no-at-sign")
+
+    def test_model_validate_from_dict(self):
+        obj = Simple.model_validate({"name": "from-dict", "score": 3.14})
+        assert obj.name == "from-dict"
+        assert obj.score == pytest.approx(3.14)
+
+    def test_model_validate_invalid_raises(self):
+        with pytest.raises(ValidationError):
+            Simple.model_validate({"score": "bad"})
+
+    def test_extra_fields_ignored(self):
+        obj = Simple.model_validate({"name": "x", "unknown_key": 99})
+        assert obj.name == "x"
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_model_dump_returns_dict(self):
+        d = Simple(name="dump-test", score=1.0).model_dump()
+        assert isinstance(d, dict)
+        assert d["name"] == "dump-test"
+        assert d["score"] == 1.0
+
+    def test_model_dump_includes_all_fields(self):
+        d = Simple(name="x").model_dump()
+        assert set(d.keys()) >= {"id", "name", "score", "active", "tags", "notes"}
+
+    def test_model_dump_json_roundtrip(self):
+        obj = Simple(name="json", score=2.5, tags=["x"])
+        parsed = Simple.model_validate_json(obj.model_dump_json())
+        assert parsed.name == "json"
+        assert parsed.score == pytest.approx(2.5)
+        assert parsed.tags == ["x"]
+
+    def test_model_dump_exclude_none(self):
+        d = Simple(name="x").model_dump(exclude_none=True)
+        assert "notes" not in d
+        assert "name" in d
+
+    def test_to_dict_helper(self):
+        assert Simple(name="x").to_dict()["name"] == "x"
+
+    def test_to_json_helper(self):
+        assert "x" in Simple(name="x").to_json()
+
+
+# ---------------------------------------------------------------------------
+# model_construct (bypasses validation)
+# ---------------------------------------------------------------------------
+
+
+class TestModelConstruct:
+    def test_construct_with_fields(self):
+        obj = Simple.model_construct(name="constructed", score=7.0)
+        assert obj.name == "constructed"
+        assert obj.score == 7.0
+
+    def test_construct_allows_partial(self):
+        obj = Simple.model_construct(score=5.0)
+        assert obj.score == 5.0
+
+    def test_construct_skips_validators(self):
+        obj = WithValidator.model_construct(username="UPPER", email="no-at")
+        assert obj.username == "UPPER"
+
+    def test_construct_persisted_false(self):
+        assert Simple.model_construct(name="x")._persisted is False
+
+
+# ---------------------------------------------------------------------------
+# model_copy
+# ---------------------------------------------------------------------------
+
+
+class TestModelCopy:
+    def test_copy_is_new_instance(self):
+        obj = Simple(name="original")
+        assert obj.model_copy() is not obj
+
+    def test_copy_preserves_values(self):
+        copy = Simple(name="orig", score=3.0).model_copy()
+        assert copy.name == "orig"
+        assert copy.score == 3.0
+
+    def test_copy_with_update(self):
+        obj = Simple(name="orig", score=1.0)
+        copy = obj.model_copy(update={"score": 99.0})
+        assert copy.score == 99.0
+        assert obj.score == 1.0
+
+    def test_deep_copy(self):
+        obj = Simple(name="x", tags=["a"])
+        obj.model_copy(deep=True).tags.append("b")
+        assert obj.tags == ["a"]
+
+
+# ---------------------------------------------------------------------------
+# model_fields introspection
+# ---------------------------------------------------------------------------
+
+
+class TestModelFieldsIntrospection:
+    def test_model_fields_is_dict(self):
+        assert isinstance(Simple.model_fields, dict)
+
+    def test_model_fields_contains_expected_keys(self):
+        assert {"id", "name", "score"} <= set(Simple.model_fields)
+
+    def test_model_fields_values_are_field_info(self):
+        for name, field in Simple.model_fields.items():
+            assert isinstance(field, FieldInfo), f"{name} should be FieldInfo"
+
+    def test_model_real_fields(self):
+        assert "name" in Simple.model_real_fields()
+
+    def test_classvar_not_in_model_fields(self):
+        assert "CLASS_CONSTANT" not in WithClassVar.model_fields
+        assert "objects_count" not in WithClassVar.model_fields
+
+    def test_classvar_accessible_on_class(self):
+        assert WithClassVar.CLASS_CONSTANT == "constant"
+        assert WithClassVar.objects_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Inheritance
+# ---------------------------------------------------------------------------
+
+
+class TestInheritance:
+    def test_child_inherits_parent_fields(self):
+        obj = Child(base_field="hello")
+        assert obj.base_field == "hello"
+        assert obj.child_field == 42
+
+    def test_child_model_fields_includes_inherited(self):
+        assert "base_field" in Child.model_fields
+        assert "child_field" in Child.model_fields
+
+    def test_parent_model_fields_unchanged(self):
+        assert "child_field" not in Parent.model_fields
+
+    def test_isinstance_chain(self):
+        obj = Child(base_field="x")
+        assert isinstance(obj, Child)
+        assert isinstance(obj, Parent)
+        assert isinstance(obj, Model)
+
+    def test_child_default_not_corrupted(self):
+        # Regression: metaclass-based FieldRef previously corrupted inherited
+        # field defaults in subclasses (e.g. Child.id.default became FieldRef).
+        assert Child.model_fields["id"].default is None
+        assert Child(base_field="x").id is None
+
+
+# ---------------------------------------------------------------------------
+# PrivateAttr
+# ---------------------------------------------------------------------------
+
+
+class TestPrivateAttr:
+    def test_persisted_defaults_false(self):
+        assert Simple(name="x")._persisted is False
+
+    def test_persisted_can_be_set(self):
+        obj = Simple(name="x")
+        obj._persisted = True
+        assert obj._persisted is True
+
+    def test_persisted_not_in_model_dump(self):
+        obj = Simple(name="x")
+        obj._persisted = True
+        assert "_persisted" not in obj.model_dump()
+
+    def test_persisted_not_in_model_fields(self):
+        assert "_persisted" not in Simple.model_fields

--- a/tests/test_write_operations.py
+++ b/tests/test_write_operations.py
@@ -142,9 +142,7 @@ async def test_get_or_create_creates_when_missing(db_setup_and_teardown):
 
 @pytest.mark.asyncio
 async def test_get_or_create_returns_existing_without_update(db_setup_and_teardown):
-    original = await User.objects.create(
-        username="alice", email="alice@ex.com", is_active=True
-    )
+    original = await User.objects.create(username="alice", email="alice@ex.com", is_active=True)
 
     user, created = await User.objects.get_or_create(
         username="alice",


### PR DESCRIPTION
## Summary

Adds partial-column loading to the query API so callers can fetch a subset of
columns instead of `SELECT *`.

- **`QuerySet.only(*fields)`** restricts the SELECT to the named columns;
  **`QuerySet.defer(*fields)`** selects everything except them. Mutually
  exclusive (each clears the other); `Manager` and `Model` expose pass-throughs.
- **Typed field references** via `FieldRef` and the `Model.f` namespace
  (`User.f.username`) — validated against real columns at the call site, so
  typos/renames raise immediately. Plain strings still accepted.
- **Primary key is always loaded** (even if omitted from `only()` or named in
  `defer()`), mirroring Django, so partial instances stay identity-safe.
- **Save safety:** `save()` on a partial instance confines its UPDATE to the
  loaded columns, so un-fetched columns are never clobbered with Python
  defaults. Adds `save(update_fields=[...])` to write an explicit subset.
- **Explicit failure** when combined with `select_related()` — raises
  `ValueError` instead of silently ignoring the column restriction.
- Partial rows hydrate via `model_construct()` (no validation; defaults fill
  unselected optional fields) and record `_loaded_fields`.
- Docs: `docs/USAGE.md` section + ADR 0004 (design, save-safety, caveats).

## Test plan

- [x] Unit tests: `FieldRef`/`Model.f`, field-name storage, mutual exclusivity, unknown/virtual-field rejection
- [x] Integration (Postgres + MySQL): `only()`/`defer()`, PK-always-loaded, no-clobber save, `update_fields`, composition with `filter()`/`order_by()`/`first()`, `count()`/`exists()`, `select_related()` guard
- [x] Pydantic-compatibility regression suite (instance access, validation, serialization, copy, inheritance, private attrs)
- [x] Full suite: **488 passing** on both backends, no regressions
- [x] `ruff` + `mypy` clean

Closes #50