### PR TITLE
feat(#101): apply unique / index Field metadata in CREATE TABLE

### DIFF
--- a/docs/adr/0005-unique-index-ddl.md
+++ b/docs/adr/0005-unique-index-ddl.md
@@ -1,0 +1,44 @@
+# 0005 — Apply `unique` / `index` Field metadata in DDL
+
+**Status:** accepted
+**Date:** 2026-06-27
+
+## Context
+
+`Field(unique=True)`, `Field(index=True)` and `Field(db_column=...)` were
+accepted by `Field()` and stored on `FieldMeta`, but `create_table` only ever
+read `max_length`. The constraints were silent no-ops — a real correctness
+surprise (issue #101). Two questions had to be resolved:
+
+1. How to emit `UNIQUE` and an index portably across Postgres and MySQL.
+2. Whether `db_column` belongs in the same change.
+
+`db_column` is fundamentally different: it requires a field-name ⇄ column-name
+mapping at *every* call site that names a column — DDL, INSERT/UPDATE column
+lists, SELECT projection, `WHERE` building, `select_related` aliases, and the
+reverse direction when hydrating rows back into instances. That is invasive and
+risk-bearing.
+
+## Decision
+
+Apply `unique` and `index` in `create_table` now; **split `db_column` into its
+own issue** (#104) so this change stays small and reviewable.
+
+- `unique`: rendered as a column-level `UNIQUE` (portable on both backends).
+- `index`: emitted as a separate `CREATE INDEX idx_<table>_<col>` statement
+  after the `CREATE TABLE`, via a new `Dialect.create_index()` method. Postgres
+  overrides it to add `IF NOT EXISTS` (idempotent); MySQL has no such clause, so
+  it relies on tables being dropped before recreation.
+- A unique column already has an implicit index, so a standalone index is only
+  emitted for `index=True and not unique` non-PK columns (no redundant index).
+
+## Consequences
+
+- `Field(unique=True)` / `Field(index=True)` now actually constrain the schema;
+  a duplicate insert raises the driver's integrity error on both backends.
+- Repeated `create_table()` is idempotent on Postgres but not MySQL (no
+  `CREATE INDEX IF NOT EXISTS`); acceptable because the test fixture and
+  migrations drop first. Revisit if standalone re-runs become a use case.
+- `db_column` remains a silent no-op until #104; documented there, not here.
+- Composite / multi-column unique constraints and named constraints are out of
+  scope — single-column only for now.

--- a/riverorm/models.py
+++ b/riverorm/models.py
@@ -669,6 +669,7 @@ class Model(BaseModel):
         db = cls.db()
         dialect = db.dialect
         parts = []
+        index_columns: list[str] = []
         pk_name = cls.primary_key()
         # MySQL cannot index/key a TEXT column without a length, so a string PK
         # must be a bounded VARCHAR. Default the bound when none was declared.
@@ -698,11 +699,21 @@ class Model(BaseModel):
             column = f"{dialect.quote(name)} {db_field_type}"
             if is_pk:
                 column += " PRIMARY KEY"
-            elif not is_nullable(field_type):
-                column += " NOT NULL"
+            else:
+                if not is_nullable(field_type):
+                    column += " NOT NULL"
+                if meta.unique:
+                    column += " UNIQUE"
             parts.append(column)
+            # A unique column already has an implicit index; only add a standalone
+            # one for index-without-unique, non-PK columns.
+            if meta.index and not meta.unique and not is_pk:
+                index_columns.append(name)
         sql = f"CREATE TABLE IF NOT EXISTS {dialect.quote(cls.table_name())} ({', '.join(parts)});"
-        return await db.execute(sql)
+        await db.execute(sql)
+        table = cls.table_name()
+        for col in index_columns:
+            await db.execute(dialect.create_index(table, col, name=f"idx_{table}_{col}"))
 
     @classmethod
     async def drop_table(cls: type[T]):

--- a/riverorm/sql/dialect.py
+++ b/riverorm/sql/dialect.py
@@ -44,6 +44,18 @@ class Dialect(ABC):
         """Render a variable-length string column type with a length bound."""
         return f"VARCHAR({length})"
 
+    def create_index(self, table: str, column: str, *, name: str, unique: bool = False) -> str:
+        """Render a ``CREATE INDEX`` statement for a single column.
+
+        The base form is portable; dialects that support ``IF NOT EXISTS``
+        override this to make repeated calls idempotent.
+        """
+        unique_kw = "UNIQUE " if unique else ""
+        return (
+            f"CREATE {unique_kw}INDEX {self.quote(name)} "
+            f"ON {self.quote(table)} ({self.quote(column)});"
+        )
+
     def render_returning(self, column: str) -> str:
         """Render a ``RETURNING <column>`` clause for an insert.
 
@@ -117,6 +129,15 @@ class PostgresDialect(Dialect):
 
     def auto_increment_pk(self, column: str) -> str:
         return f"{self.quote(column)} SERIAL PRIMARY KEY"
+
+    def create_index(self, table: str, column: str, *, name: str, unique: bool = False) -> str:
+        # Postgres supports IF NOT EXISTS on CREATE INDEX, so repeated calls are
+        # idempotent. (MySQL does not, hence no override there.)
+        unique_kw = "UNIQUE " if unique else ""
+        return (
+            f"CREATE {unique_kw}INDEX IF NOT EXISTS {self.quote(name)} "
+            f"ON {self.quote(table)} ({self.quote(column)});"
+        )
 
 
 class MySQLDialect(Dialect):

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -1,0 +1,94 @@
+"""DDL generation tests: unique / index Field metadata applied to CREATE TABLE.
+
+Covers the pure dialect SQL, the statements ``create_table`` actually emits, and
+a real uniqueness-constraint violation on both backends.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from riverorm import Field, Model
+from riverorm.sql.dialect import MySQLDialect, PostgresDialect
+
+
+class Account(Model):
+    id: int | None = Field(default=None)
+    email: str = Field(unique=True, max_length=200)
+    slug: str = Field(index=True, max_length=100)
+    name: str = Field(default="", max_length=100)
+
+
+@pytest.fixture
+def db_models() -> list[type[Model]]:
+    # Override the conftest default so the fixture creates/drops our DDL model.
+    return [Account]
+
+
+# ---------------------------------------------------------------------------
+# Pure dialect SQL (no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_postgres_create_index_is_idempotent():
+    sql = PostgresDialect().create_index("account", "slug", name="idx_account_slug")
+    assert sql == 'CREATE INDEX IF NOT EXISTS "idx_account_slug" ON "account" ("slug");'
+
+
+def test_postgres_create_unique_index():
+    sql = PostgresDialect().create_index("account", "email", name="uq_account_email", unique=True)
+    assert sql == ('CREATE UNIQUE INDEX IF NOT EXISTS "uq_account_email" ON "account" ("email");')
+
+
+def test_mysql_create_index_uses_backticks():
+    sql = MySQLDialect().create_index("account", "slug", name="idx_account_slug")
+    assert sql == "CREATE INDEX `idx_account_slug` ON `account` (`slug`);"
+
+
+# ---------------------------------------------------------------------------
+# create_table emits the right statements (capture, no real execution)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_table_emits_unique_and_index(monkeypatch):
+    executed: list[str] = []
+
+    async def fake_execute(sql: str, *args):
+        executed.append(sql)
+
+    monkeypatch.setattr(Account.db(), "execute", fake_execute)
+
+    await Account.create_table()
+
+    create = next(s for s in executed if s.startswith("CREATE TABLE"))
+    # UNIQUE is attached to the unique column...
+    assert "UNIQUE" in create
+    assert "email" in create
+    # ...and a standalone CREATE INDEX is emitted for the indexed (non-unique) column.
+    index_stmts = [s for s in executed if s.startswith("CREATE") and "INDEX" in s]
+    assert any("slug" in s for s in index_stmts)
+    # The unique column does not get a second, redundant standalone index.
+    assert not any("email" in s for s in index_stmts)
+
+
+# ---------------------------------------------------------------------------
+# Real constraint enforcement (both backends via conftest parametrization)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unique_constraint_rejects_duplicate(db_setup_and_teardown):
+    await Account(email="a@ex.com", slug="alpha").save()
+
+    with pytest.raises(Exception):  # noqa: B017 - driver-specific IntegrityError
+        await Account(email="a@ex.com", slug="beta").save()
+
+
+@pytest.mark.asyncio
+async def test_unique_constraint_allows_distinct(db_setup_and_teardown):
+    await Account(email="a@ex.com", slug="alpha").save()
+    await Account(email="b@ex.com", slug="beta").save()
+
+    rows = await Account.objects.all()
+    assert {r.email for r in rows} == {"a@ex.com", "b@ex.com"}


### PR DESCRIPTION
## Summary

`Field(unique=True)` and `Field(index=True)` were accepted and stored on `FieldMeta` but **never emitted in DDL** — silent no-op constraints (a correctness surprise). This wires them into `create_table`.

- **`unique`** → column-level `UNIQUE` (portable on both backends).
- **`index`** → a standalone `CREATE INDEX idx_<table>_<col>` after the table, via a new `Dialect.create_index()`. Postgres adds `IF NOT EXISTS` (idempotent); MySQL relies on drop-before-create.
- A unique column already has an implicit index, so a standalone index is emitted only for `index=True and not unique` non-PK columns (no redundant index).

## Scope decision (ADR 0005)
`db_column` was **split into #104**. Unlike DDL-only `unique`/`index`, it needs a field⇄column mapping at every call site (queries, save, and row hydration), so bundling it would make this PR large and risky. #101 is now scoped to unique/index; #101 title and ADR 0005 reflect this.

## Test plan
- [x] `tests/test_ddl.py`: pure dialect SQL (PG + MySQL), `create_table` emits UNIQUE + CREATE INDEX (captured, no redundant index on unique col), real uniqueness violation rejected on **both backends**
- [x] Full suite: **524 passing**
- [x] `ruff` + `mypy` clean

Closes #101