### PR TITLE
docs(adr): 0006 transaction design (proposed)

### DIFF
--- a/docs/adr/0006-transactions.md
+++ b/docs/adr/0006-transactions.md
@@ -1,0 +1,167 @@
+# 0006 — Transaction support (ContextVar-bound, pool-staged)
+
+**Status:** proposed (pending maintainer decisions — see Open questions)
+**Date:** 2026-06-27
+
+## Context
+
+RiverORM has **no transaction API** — only TODO comments, and `get_or_create`
+documents "this is not atomic; wrap in a transaction" with nothing to wrap it
+in (#102). A production ORM needs explicit, ergonomic transactions.
+
+### Current architecture (what constrains us)
+
+- Both backends hold a **single shared driver connection** for the process
+  lifetime; there is **no pool**. `PostgresDatabase` keeps one
+  `asyncpg.Connection`; `MySQLDatabase` keeps one `aiomysql.Connection` opened
+  with **`autocommit=True`**.
+- Every read/write funnels through `Model.db()` → a `BaseDatabase` method
+  (`execute`/`fetch`/`fetchrow`/`update`/`execute_insert`/
+  `execute_returning_rowcount`). There is **no notion of a "current connection"**
+  that a sequence of operations shares — each call is an independent,
+  autocommitting statement.
+- `DatabaseRegistry.get(alias)` returns the same shared `BaseDatabase` instance
+  every time.
+
+Consequence: *binding* in-transaction operations is easy (one path,
+`Model.db()`), but the *connection model* is the hard part — one shared
+connection cannot safely host concurrent transactions from different async
+tasks.
+
+### How peers solve it (discovery)
+
+Convergent pattern across SQLAlchemy 2.0, Django, **Tortoise ORM**, encode
+`databases`, and Peewee: **one nestable construct** (context manager + decorator),
+outermost = `BEGIN`/`COMMIT`, inner = `SAVEPOINT`, rollback-on-exception. Every
+async ORM binds the active connection per task with **`contextvars`** so model
+calls inside the block need no explicit handle (Tortoise sets a `ContextVar` to
+the transaction connection and `reset()`s it on exit; encode `databases` ties
+"transaction state to the connection used in the current async task"). Peewee's
+single reentrant `atomic()` (transaction at depth 0, savepoint deeper) is the
+ergonomic gold standard. See Sources.
+
+## Decision
+
+Adopt **ContextVar-bound transactions with a connection pool, staged in two
+steps so the public API never changes:**
+
+1. **Phase 1 — API on the shared connection.** Add `transaction()` to
+   `BaseDatabase` and a `ContextVar` recording the active transaction. Inside the
+   block, statements run on the existing shared connection without autocommit;
+   `COMMIT` on clean exit, `ROLLBACK` on exception. Documented limitation: **one
+   transaction at a time per backend** (concurrent transactions are unsafe on a
+   single connection).
+2. **Phase 2 — pool underneath (non-breaking).** Replace the single connection
+   with `asyncpg.create_pool` / `aiomysql.create_pool`. A
+   `ContextVar[Connection | None]` holds the task's checked-out connection;
+   `execute/fetch/...` use it when set, else acquire a one-off connection. This
+   makes concurrent transactions correct. **User code is unchanged.**
+
+### Public API
+
+```python
+# Context manager (primary form)
+async with User.db().transaction():
+    user = await User.objects.create(username="alice")
+    await Order(user_id=user.id, ...).save()
+# COMMIT on success; any exception → ROLLBACK, then re-raises
+
+# Decorator
+@atomic()                      # or @atomic(alias="reporting")
+async def transfer(...): ...
+
+# Nested → SAVEPOINTs
+async with db.transaction():
+    await a.save()
+    async with db.transaction():   # SAVEPOINT
+        await b.save()             # rolls back to savepoint on inner error
+```
+
+One implementation backs `db.transaction()`, an `atomic()` decorator, and an
+optional `Model.transaction()` convenience.
+
+### Binding mechanism
+
+A module-level `ContextVar` (keyed per alias) holds the active transaction
+connection. The six `BaseDatabase` methods consult it: bound → use the
+transaction connection; unbound → today's shared connection (Phase 1) or a
+pooled one-off (Phase 2). This keeps **all changes inside `BaseDatabase` /
+`postgres.py` / `mysql.py`** — `models.py` and `queryset.py` call sites are
+untouched.
+
+### FastAPI integration (first-class — see #108)
+
+The design is shaped so it drops into FastAPI cleanly:
+
+```python
+from contextlib import asynccontextmanager
+from fastapi import Depends, FastAPI
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    DatabaseRegistry.register("default", PostgresDatabase(DSN))
+    await DatabaseRegistry.connect()     # Phase 2: opens the pool
+    yield
+    await DatabaseRegistry.close()       # closes the pool
+
+app = FastAPI(lifespan=lifespan)
+
+async def tx():                          # per-request transaction dependency
+    async with User.db().transaction():
+        yield
+
+@app.post("/users")
+async def create_user(body: UserIn, _=Depends(tx)) -> User:
+    return await User.objects.create(**body.model_dump())
+```
+
+- **Lifespan** owns pool startup/shutdown via `DatabaseRegistry.connect()/close()`.
+- A **dependency** wraps each request in a transaction (commit on success,
+  rollback when the endpoint raises). Per-request isolation is exactly what the
+  ContextVar/pool model provides — each request runs in its own async task.
+- RiverORM models *are* Pydantic models, so they double as FastAPI
+  request/response schemas.
+
+This is why the connection model (pool + ContextVar) matters: it is what makes
+the per-request FastAPI pattern correct under concurrency.
+
+## Consequences
+
+- **Ergonomic, implicit binding:** `await user.save()` inside the block just
+  works — the dominant use case (multi-write business ops, `get_or_create`)
+  with zero call-site churn.
+- **MySQL autocommit becomes conditional:** inside a transaction the aiomysql
+  connection must be `autocommit=False` (or `conn.begin()`), restored on exit —
+  a real behavioral change to `mysql.py`.
+- **Phase 2 introduces a pool:** `connect()`/`close()` become pool create/close;
+  `is_connected` shifts from "have a connection" to "pool open." Adds pool-size
+  config surface (where? `config.py` vs DSN params).
+- **Hidden per-task state** (the ContextVar) is accepted as the cost of
+  ergonomic binding; document the caveat: do not share one transaction across
+  concurrently-running `asyncio.gather` tasks.
+- **`get_or_create` becomes atomic** when wrapped, closing its documented gap.
+- Phase 1 transactions are **not concurrency-safe** until Phase 2 lands — a
+  documented interim limitation if we ship Phase 1 alone.
+
+## Open questions (maintainer decisions)
+
+1. **Ship order:** land Phase 1 (API on shared connection, documented
+   single-transaction caveat) first, or go straight to Phase 2 (pool) so the
+   first transactional release is concurrency-safe (FastAPI-ready)?
+2. **Savepoints in v1:** real nested SAVEPOINTs now, or flat "outermost only"
+   first with nesting later?
+3. **Pool config:** min/max size and where it's configured (kept minimal per the
+   project mission).
+4. **Public entry points:** `db.transaction()` only, or also
+   `DatabaseRegistry.transaction(alias)` and `Model.transaction()`?
+5. **asyncpg native vs. raw SQL:** use asyncpg's built-in
+   `connection.transaction()` (handles savepoints) vs. raw `BEGIN`/`SAVEPOINT`
+   via the dialect for symmetry with the aiomysql path.
+
+## Sources
+
+- SQLAlchemy 2.0 async — https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html
+- Django transactions — https://docs.djangoproject.com/en/5.1/topics/db/transactions/
+- Tortoise ORM transactions — https://tortoise.github.io/transactions.html
+- encode `databases` — https://www.encode.io/databases/connections_and_transactions/
+- Peewee transactions — https://docs.peewee-orm.com/en/latest/peewee/transactions.html

--- a/docs/adr/0006-transactions.md
+++ b/docs/adr/0006-transactions.md
@@ -1,7 +1,7 @@
 # 0006 — Transaction support (ContextVar-bound, pool-staged)
 
-**Status:** proposed (pending maintainer decisions — see Open questions)
-**Date:** 2026-06-27
+**Status:** accepted
+**Date:** 2026-06-27 (decisions resolved 2026-06-28)
 
 ## Context
 
@@ -42,20 +42,24 @@ ergonomic gold standard. See Sources.
 
 ## Decision
 
-Adopt **ContextVar-bound transactions with a connection pool, staged in two
-steps so the public API never changes:**
+Adopt **ContextVar-bound transactions on a connection pool**, implemented
+directly (no staging — the maintainer chose to ship concurrency-safe from day
+one so FastAPI per-request transactions are correct immediately):
 
-1. **Phase 1 — API on the shared connection.** Add `transaction()` to
-   `BaseDatabase` and a `ContextVar` recording the active transaction. Inside the
-   block, statements run on the existing shared connection without autocommit;
-   `COMMIT` on clean exit, `ROLLBACK` on exception. Documented limitation: **one
-   transaction at a time per backend** (concurrent transactions are unsafe on a
-   single connection).
-2. **Phase 2 — pool underneath (non-breaking).** Replace the single connection
-   with `asyncpg.create_pool` / `aiomysql.create_pool`. A
-   `ContextVar[Connection | None]` holds the task's checked-out connection;
-   `execute/fetch/...` use it when set, else acquire a one-off connection. This
-   makes concurrent transactions correct. **User code is unchanged.**
+- Replace each backend's single shared connection with a pool
+  (`asyncpg.create_pool` / `aiomysql.create_pool`). `connect()`/`close()` become
+  pool create/close.
+- A `ContextVar[Connection | None]` (keyed per alias) holds the **checked-out
+  connection for the current async task**. Entering `transaction()` acquires a
+  pool connection, issues `BEGIN`, and `set()`s the ContextVar (keeping the
+  token); on exit `COMMIT`/`ROLLBACK`, release to the pool, `reset(token)`.
+- The six `BaseDatabase` methods route to `ContextVar.get()` when a transaction
+  is active, else acquire a one-off pooled connection (autocommit) for the
+  statement. **`models.py`/`queryset.py` call sites are untouched.**
+
+This is exactly Tortoise's / encode-`databases`' model and gives correct
+per-task isolation: concurrent FastAPI requests each run in their own task,
+hence their own transaction connection.
 
 ### Public API
 
@@ -77,8 +81,18 @@ async with db.transaction():
         await b.save()             # rolls back to savepoint on inner error
 ```
 
-One implementation backs `db.transaction()`, an `atomic()` decorator, and an
-optional `Model.transaction()` convenience.
+**All four entry points ship**, one implementation behind them:
+
+- `db.transaction()` — core form on a `BaseDatabase`.
+- `@atomic(alias=None)` — decorator wrapping an async function (ideal as a
+  FastAPI dependency / service method).
+- `Model.transaction()` — convenience routing to the model's `Meta.db_alias`.
+- `DatabaseRegistry.transaction(alias)` — explicit alias selection for multi-DB
+  apps.
+
+**Nesting ships in v1 with real SAVEPOINTs:** a nested `async with
+db.transaction()` (depth ≥ 1) emits `SAVEPOINT`/`RELEASE`/`ROLLBACK TO`; an inner
+rollback leaves the outer transaction intact. Reentrant like Peewee's `atomic()`.
 
 ### Binding mechanism
 
@@ -133,30 +147,30 @@ the per-request FastAPI pattern correct under concurrency.
 - **MySQL autocommit becomes conditional:** inside a transaction the aiomysql
   connection must be `autocommit=False` (or `conn.begin()`), restored on exit —
   a real behavioral change to `mysql.py`.
-- **Phase 2 introduces a pool:** `connect()`/`close()` become pool create/close;
-  `is_connected` shifts from "have a connection" to "pool open." Adds pool-size
-  config surface (where? `config.py` vs DSN params).
+- **A pool replaces the single connection:** `connect()`/`close()` become pool
+  create/close; `is_connected` shifts from "have a connection" to "pool open."
+  This is a real rewrite of `postgres.py`/`mysql.py` and the largest part of the
+  work.
 - **Hidden per-task state** (the ContextVar) is accepted as the cost of
   ergonomic binding; document the caveat: do not share one transaction across
   concurrently-running `asyncio.gather` tasks.
 - **`get_or_create` becomes atomic** when wrapped, closing its documented gap.
-- Phase 1 transactions are **not concurrency-safe** until Phase 2 lands — a
-  documented interim limitation if we ship Phase 1 alone.
+## Resolved decisions
 
-## Open questions (maintainer decisions)
+1. **Connection model — pool from day one.** No staging; implement the pool +
+   ContextVar directly so transactions are concurrency-safe and FastAPI-ready
+   immediately.
+2. **Nesting — real SAVEPOINTs in v1** (reentrant `transaction()`).
+3. **Entry points — all four ship:** `db.transaction()`, `@atomic()`,
+   `Model.transaction()`, `DatabaseRegistry.transaction(alias)`.
+4. **Pool config — minimal:** sensible default min/max sizes; expose overrides
+   later (DSN query params or `config.py`) only if needed, per the minimalistic
+   mission.
+5. **SAVEPOINT/BEGIN rendering — raw SQL via the dialect** for both backends, so
+   Postgres and MySQL share one transaction code path (over asyncpg's native
+   `connection.transaction()`), keeping behavior symmetric and testable.
 
-1. **Ship order:** land Phase 1 (API on shared connection, documented
-   single-transaction caveat) first, or go straight to Phase 2 (pool) so the
-   first transactional release is concurrency-safe (FastAPI-ready)?
-2. **Savepoints in v1:** real nested SAVEPOINTs now, or flat "outermost only"
-   first with nesting later?
-3. **Pool config:** min/max size and where it's configured (kept minimal per the
-   project mission).
-4. **Public entry points:** `db.transaction()` only, or also
-   `DatabaseRegistry.transaction(alias)` and `Model.transaction()`?
-5. **asyncpg native vs. raw SQL:** use asyncpg's built-in
-   `connection.transaction()` (handles savepoints) vs. raw `BEGIN`/`SAVEPOINT`
-   via the dialect for symmetry with the aiomysql path.
+Implementation tracked in #102; FastAPI guide/example in #108.
 
 ## Sources
 


### PR DESCRIPTION
## Summary

Draft **ADR 0006** for transaction support (#102), informed by a focused survey of how SQLAlchemy 2.0, Django, **Tortoise**, encode/`databases`, and Peewee handle transactions and connection binding.

### Findings
- **Today:** single shared connection per backend, no pool, MySQL `autocommit=True`; no shared transactional unit.
- **Industry pattern:** one nestable construct (context-manager + decorator), outermost `BEGIN`/`COMMIT`, inner `SAVEPOINT`, rollback-on-exception, **contextvars** to bind the active connection per async task.

### Recommendation
ContextVar-bound `transaction()` / `atomic()`, **staged**:
1. Ship the API on the current shared connection (documented "one transaction at a time" caveat).
2. Swap in a pool underneath — **non-breaking**, makes concurrent transactions correct.

All changes stay inside `BaseDatabase` / `postgres.py` / `mysql.py`; `models.py`/`queryset.py` untouched.

### FastAPI (per @maintainer request, #108)
ADR includes a FastAPI section: lifespan-managed pool + a per-request transaction dependency. RiverORM models are Pydantic, so they double as request/response schemas.

## This PR is a proposal
Status is `proposed`. It does **not** implement transactions — it captures the design and surfaces 5 open questions (ship order, savepoints in v1, pool config, public entry points, asyncpg-native vs raw SQL) for decision before implementation.

Refs #102, #108